### PR TITLE
Improve README note navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 | [NUS](#nus) | School coursework, module notes, and academic projects |
 | [AI & Emerging Tech](#ai-emerging-tech) | High-performance AI workloads and modern ML infrastructure |
 
+<div style="margin-top: 1.5rem;"></div>
+
 <a id="architecture-cloud-operations"></a>
 <details>
 <summary><strong>Architecture, Cloud & Operations</strong></summary>

--- a/README.md
+++ b/README.md
@@ -53,122 +53,1385 @@ I am planning to work on my notes daily for the next **10 years**, building a se
 
 ## Notes Navigator 🧭
 
-Use the quick index below to jump straight to the topics you care about, then expand any section to explore the related notes.
+Use the quick index below to jump straight to the topics you care about. Expand any domain to browse the underlying tags and linked notes.
 
-| Domain | Quick Jump |
+| Domain | Focus |
 | --- | --- |
-| 🏭 [System Design](#system-design) | Scalability foundations, service roles, and architecture blueprints |
-| 💻 [Operating System](#operating-system) | CPU, memory, processes, interrupts, and more |
-| 🖥️ [Computer Organisation](#computer-organisation) | ISA families, pipelines, and digital logic |
-| 🧠 [Data Structure & Algorithm](#data-structure--algorithm) | Core patterns for solving problems |
-| 👩‍💻 [Competitive Programming](#competitive-programming) | Templates and topic-based practice guides |
-| ➕ [Math](#math) | Number theory and discrete mathematics refreshers |
-| 🔤 [Programming Language](#programming-language) | Language-specific idioms and best practices |
-| 🛠️ [Software Engineering](#software-engineering) | Engineering principles, tooling, and operations |
-| 🕸️ [Networking](#networking) | Protocol fundamentals and revision notes |
+| [Architecture, Cloud & Operations](#architecture-cloud-operations) | System design blueprints, observability, and cloud platform building blocks |
+| [Networking & Distributed Systems](#networking-distributed-systems) | Protocols, distributed primitives, and edge connectivity |
+| [Operating Systems, Hardware & HPC](#operating-systems-hardware-hpc) | Kernel internals, memory models, and digital logic |
+| [Programming Languages & Paradigms](#programming-languages-paradigms) | Language idioms, paradigms, and ecosystem insights |
+| [Software Engineering & Tooling](#software-engineering-tooling) | Engineering workflows, CLI mastery, and productivity tooling |
+| [Algorithms, Data Structures & Math](#algorithms-data-structures-math) | Problem-solving playbooks, math fundamentals, and contest prep |
+| [Data Management](#data-management) | Relational theory, storage engines, and SQL patterns |
+| [Security & Identity](#security-identity) | Security architecture, authentication, and enterprise trust |
+| [Career, Finance & Academia](#career-finance-academia) | Professional growth, financial literacy, and academic references |
+| [AI & Emerging Tech](#ai-emerging-tech) | High-performance AI workloads and modern ML infrastructure |
+| [Visual Library](#visual-library) | Hand-crafted Excalidraw diagrams and visual aids |
 
-<a id="system-design"></a>
-<details open>
-<summary><strong>🏭 System Design</strong></summary>
-
-- [Basis](https://notes.yxy.ninja/System-Design/)
-- [Proxy](https://notes.yxy.ninja/System-Design/Proxy/)
-- [Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/)
-- [Database](https://notes.yxy.ninja/System-Design/Database/)
-- [Cache](https://notes.yxy.ninja/System-Design/Cache/)
-- [Compute](https://notes.yxy.ninja/System-Design/Compute/)
-- [Monitoring](https://notes.yxy.ninja/System-Design/Monitoring/)
-- [Architecture](https://notes.yxy.ninja/System-Design/Architectures/)
-
-<a id="operating-system"></a>
+<a id="architecture-cloud-operations"></a>
 <details>
-<summary><strong>💻 Operating System</strong></summary>
+<summary><strong>Architecture, Cloud & Operations</strong></summary>
 
-- [Intro](https://notes.yxy.ninja/OS/)
-- [CPU](https://notes.yxy.ninja/OS/CPU/)
-- [File System](https://notes.yxy.ninja/OS/File-System/)
-- [IO](https://notes.yxy.ninja/OS/IO/)
-- [Memory](https://notes.yxy.ninja/OS/Memory/)
-- [Process (进程)](https://notes.yxy.ninja/OS/Process/)
-- [Thread (线程)](https://notes.yxy.ninja/OS/Thread/)
-- [Synchronization (同步)](https://notes.yxy.ninja/OS/Synchronization/)
-- [Interrupt (中断)](https://notes.yxy.ninja/OS/Interrupt/)
-- [System-Calls (系统调用)](https://notes.yxy.ninja/OS/System-Call/)
-- [UNIX vs Linux](https://notes.yxy.ninja/OS/UNIX-vs-Linux/)
-- [MISC](https://notes.yxy.ninja/OS/Terminologies/)
-
-<a id="computer-organisation"></a>
 <details>
-<summary><strong>🖥️ Computer Organisation</strong></summary>
+<summary><code>system_design</code> · 24 notes</summary>
 
-- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/)
-- [Processor](https://notes.yxy.ninja/Computer-Organisation/Processor/)
-- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/)
-- [MIPS](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/)
-- [RISCV](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/)
-- [Pipeline](https://notes.yxy.ninja/Computer-Organisation/Pipeline/)
-- [Pipeline Branching](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/)
-- [Pipeline Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/)
-- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/)
-- [Combination Circuit](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/)
-- [Sequential Circuit](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/)
-- [Circuit Design](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/)
-
-<a id="data-structure--algorithm"></a>
-<details>
-<summary><strong>🧠 Data Structure & Algorithm</strong></summary>
-
-- [Problem Solving Tricks](https://notes.yxy.ninja/tags/problem_solving)
-- [Algorithm](https://notes.yxy.ninja/Algorithm/Algorithm-Content-Page)
-- [Data Structure](https://notes.yxy.ninja/Data-Structure/Data-Structure-Content-Page)
-
-<a id="competitive-programming"></a>
-<details>
-<summary><strong>👩‍💻 Competitive Programming</strong></summary>
-
-- [Code Template](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
-- [Data Structure](https://notes.yxy.ninja/cp/data_structure/)
-- [Prefix Sum](https://notes.yxy.ninja/cp/prefix_sum/)
-- [Dynamic Programming](https://notes.yxy.ninja/cp/dynamic_programming/)
-- [Greedy](https://notes.yxy.ninja/cp/greedy/)
-- [Number Theory](https://notes.yxy.ninja/cp/number_theory/)
-- [Combinatorics](https://notes.yxy.ninja/cp/combinatorics/)
-
-<a id="math"></a>
-<details>
-<summary><strong>➕ Math</strong></summary>
-
-- [Number Theory Basis](https://notes.yxy.ninja/tags/number_theory)
-- [Divisibility & Primes](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/)
-- [Discrete Math](https://notes.yxy.ninja/tags/discrete_math)
-- [Boolean Algebra](https://notes.yxy.ninja/tags/boolean_algebra)
-
-<a id="programming-language"></a>
-<details>
-<summary><strong>🔤 Programming Language</strong></summary>
-
-- [C](https://notes.yxy.ninja/tags/c)
-- [Python](https://notes.yxy.ninja/tags/python)
-- [Rust](https://notes.yxy.ninja/tags/rust)
-- [Java](https://notes.yxy.ninja/tags/java)
-- [Javascript](https://notes.yxy.ninja/tags/js)
-
-<a id="software-engineering"></a>
-<details>
-<summary><strong>🛠️ Software Engineering</strong></summary>
-
-- [Software Engineering Theories](https://notes.yxy.ninja/tags/software_engineering)
-- [Amazon Web Services](https://notes.yxy.ninja/tags/aws)
-- [Datadog - Application Monitoring](https://notes.yxy.ninja/tags/Datadog)
-- [Security](https://notes.yxy.ninja/tags/security)
-- [Docker (Under heavy revision)](https://notes.yxy.ninja/tags/docker)
-- [Object Oriented Programming](https://notes.yxy.ninja/tags/OOP)
-
-<a id="networking"></a>
-<details>
-<summary><strong>🕸️ Networking</strong></summary>
-
-- [Networking Basis (Under heavy revision)](https://notes.yxy.ninja/tags/networking)
+- [Application Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Application-Load-Balancer)
+- [Cache Eviction](https://notes.yxy.ninja/System-Design/Cache/Cache-Eviction)
+- [Cache Server](https://notes.yxy.ninja/System-Design/Cache/Cache-Server)
+- [CDN](https://notes.yxy.ninja/System-Design/Cache/CDN)
+- [Compute Server](https://notes.yxy.ninja/System-Design/Compute/Compute-Server)
+- [Database Partitioning](https://notes.yxy.ninja/Database/Database-Partitioning)
+- [Database Replication (数据库复制)](https://notes.yxy.ninja/System-Design/Database/Database-Replication-(数据库复制))
+- [Database Scaling](https://notes.yxy.ninja/System-Design/Database/Database-Scaling)
+- [Deployment Strategies](https://notes.yxy.ninja/System-Design/Deployment-Strategies)
+- [Event-Driven Architecture](https://notes.yxy.ninja/System-Design/Architectures/Event-Driven-Architecture)
+- [Forward Proxy (正向代理)](https://notes.yxy.ninja/System-Design/Proxy/Forward-Proxy-(正向代理))
+- [Hub and Spoke Architecture](https://notes.yxy.ninja/System-Design/Architectures/Hub-and-Spoke-Architecture)
+- [Latency Number](https://notes.yxy.ninja/System-Design/Latency-Number)
+- [Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Load-Balancer)
+- [Message Queue (消息队列)](https://notes.yxy.ninja/System-Design/Compute/Message-Queue-(消息队列))
+- [Micro-servercies Architecture](https://notes.yxy.ninja/System-Design/Architectures/Micro-servercies-Architecture)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Multi Data Center Setup](https://notes.yxy.ninja/System-Design/Compute/Multi-Data-Center-Setup)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Network Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Network-Load-Balancer)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+- [REST API](https://notes.yxy.ninja/Networking-MISC/REST-API)
+- [Reverse Proxy (反向代理)](https://notes.yxy.ninja/System-Design/Proxy/Reverse-Proxy-(反向代理))
+- [System Design](https://notes.yxy.ninja/System-Design/System-Design)
 
 </details>
 
+<details>
+<summary><code>devops</code> · 10 notes</summary>
+
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Memory Monitoring](https://notes.yxy.ninja/Devops/Memory-Monitoring)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Observability](https://notes.yxy.ninja/Devops/Observability)
+- [Prometheus](https://notes.yxy.ninja/Devops/Prometheus)
+- [Prometheus On Macos](https://notes.yxy.ninja/Devops/Prometheus-On-Macos)
+- [PromQL](https://notes.yxy.ninja/Devops/PromQL)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+- [Terraform Cheatsheet](https://notes.yxy.ninja/Tools/IaC/Terraform-Cheatsheet)
+- [Terraform Project Structure](https://notes.yxy.ninja/Tools/IaC/Terraform-Project-Structure)
+
+</details>
+
+<details>
+<summary><code>aws</code> · 22 notes</summary>
+
+- [ASG](https://notes.yxy.ninja/AWS/Compute/ASG)
+- [AWS ACL](https://notes.yxy.ninja/AWS/Security/AWS-ACL)
+- [AWS ALB](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/AWS-ALB)
+- [AWS Backup](https://notes.yxy.ninja/AWS/Disaster-Recovery/AWS-Backup)
+- [AWS Database](https://notes.yxy.ninja/AWS/Database/AWS-Database)
+- [AWS EventBridge](https://notes.yxy.ninja/AWS/AWS-EventBridge)
+- [AWS Explorer](https://notes.yxy.ninja/AWS/AWS-Explorer)
+- [AWS Lambda](https://notes.yxy.ninja/AWS/Compute/AWS-Lambda)
+- [AWS NLB](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/AWS-NLB)
+- [AWS Nuke](https://notes.yxy.ninja/AWS/AWS-Nuke)
+- [AWS Parameter Store](https://notes.yxy.ninja/AWS/Storage/AWS-Parameter-Store)
+- [AWS Subnet](https://notes.yxy.ninja/AWS/Networking/AWS-Subnet)
+- [AWS Transit Gateway](https://notes.yxy.ninja/AWS/Networking/AWS-Transit-Gateway)
+- [AWS VPC Endpoint](https://notes.yxy.ninja/AWS/Networking/AWS-VPC-Endpoint)
+- [EC2](https://notes.yxy.ninja/AWS/Compute/EC2)
+- [ECS](https://notes.yxy.ninja/AWS/Compute/ECS/ECS)
+- [ECS Exec](https://notes.yxy.ninja/AWS/Compute/ECS/ECS-Exec)
+- [EFS](https://notes.yxy.ninja/AWS/Storage/EFS)
+- [KMS](https://notes.yxy.ninja/AWS/Security/KMS)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+- [Security Group](https://notes.yxy.ninja/AWS/Security/Security-Group)
+- [Target Group](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/Target-Group)
+
+</details>
+
+<details>
+<summary><code>cloudflare</code> · 12 notes</summary>
+
+- [CDN](https://notes.yxy.ninja/System-Design/Cache/CDN)
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Cloudflare Access](https://notes.yxy.ninja/Security/Authentication/Cloudflare-Access)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [DNS Record](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Record)
+- [DNS Server](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Server)
+- [Email Routing](https://notes.yxy.ninja/Networking-Concepts/Email-Routing)
+- [Hostname](https://notes.yxy.ninja/Networking-Protocol/DNS/Hostname)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SEO](https://notes.yxy.ninja/Networking-Concepts/SEO)
+
+</details>
+
+<details>
+<summary><code>docker</code> · 12 notes</summary>
+
+- [Docker](https://notes.yxy.ninja/Tools/Docker/Docker)
+- [Docker Build](https://notes.yxy.ninja/Tools/Docker/Docker-Build)
+- [Docker Compose](https://notes.yxy.ninja/Tools/Docker/Docker-Compose)
+- [Docker Container](https://notes.yxy.ninja/Tools/Docker/3-Components/Docker-Container)
+- [Docker EXEC Command Flags](https://notes.yxy.ninja/Tools/Docker/Command-Cheatsheets/Docker-EXEC-Command-Flags)
+- [Docker Filesytem](https://notes.yxy.ninja/Tools/Docker/Docker-Filesytem)
+- [Docker Network](https://notes.yxy.ninja/Tools/Docker/Docker-Network)
+- [Docker RUN Command Flags](https://notes.yxy.ninja/Tools/Docker/Command-Cheatsheets/Docker-RUN-Command-Flags)
+- [Docker Volume](https://notes.yxy.ninja/Tools/Docker/Docker-Volume)
+- [Dockerfile](https://notes.yxy.ninja/Tools/Docker/3-Components/Dockerfile)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [Virtualisation](https://notes.yxy.ninja/Virtualisation)
+
+</details>
+
+<details>
+<summary><code>Datadog</code> · 4 notes</summary>
+
+- [Datadog](https://notes.yxy.ninja/Tools/Datadog/Datadog)
+- [Datadog APM](https://notes.yxy.ninja/Tools/Datadog/Datadog-APM)
+- [Datadog Lambda Monitoring](https://notes.yxy.ninja/Tools/Datadog/Datadog-Lambda-Monitoring)
+- [Datadog RUM](https://notes.yxy.ninja/Tools/Datadog/Datadog-RUM)
+
+</details>
+
+<details>
+<summary><code>terraform</code> · 4 notes</summary>
+
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Terraform Cheatsheet](https://notes.yxy.ninja/Tools/IaC/Terraform-Cheatsheet)
+- [Terraform Project Structure](https://notes.yxy.ninja/Tools/IaC/Terraform-Project-Structure)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
+
+</details>
+
+<details>
+<summary><code>gcp</code> · 1 note</summary>
+
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+
+</details>
+
+<details>
+<summary><code>fly_io</code> · 2 notes</summary>
+
+- [Fly.io](https://notes.yxy.ninja/Tools/Fly.io)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+
+</details>
+
+<details>
+<summary><code>ngrok</code> · 1 note</summary>
+
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+
+</details>
+
+<details>
+<summary><code>over</code> · 2 notes</summary>
+
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+
+</details>
+
+</details>
+
+<a id="networking-distributed-systems"></a>
+<details>
+<summary><strong>Networking & Distributed Systems</strong></summary>
+
+<details>
+<summary><code>networking</code> · 95 notes</summary>
+
+- [Access Control List](https://notes.yxy.ninja/Security/Access-Control-List)
+- [Access Network](https://notes.yxy.ninja/Networking-MISC/Access-Network)
+- [Address Resolution Protocol](https://notes.yxy.ninja/Networking-Protocol/Address-Resolution-Protocol)
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [AS](https://notes.yxy.ninja/Networking-Protocol/AS)
+- [AWS VPC Endpoint](https://notes.yxy.ninja/AWS/Networking/AWS-VPC-Endpoint)
+- [Bandwidth](https://notes.yxy.ninja/Networking-MISC/Bandwidth)
+- [Border Gateway Protocol](https://notes.yxy.ninja/Networking-Protocol/Border-Gateway-Protocol)
+- [Communication Links](https://notes.yxy.ninja/Networking-Devices/Communication-Links)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [CSMA](https://notes.yxy.ninja/Networking-Protocol/CSMA)
+- [DHCP](https://notes.yxy.ninja/Networking-Protocol/DHCP)
+- [Digital Signature](https://notes.yxy.ninja/Security/Cryptography/Digital-Signature)
+- [Digital Subscriber Line (DSL)](https://notes.yxy.ninja/Networking-Devices/Digital-Subscriber-Line-(DSL))
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [DNS Record](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Record)
+- [DNS Server](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Server)
+- [Docker](https://notes.yxy.ninja/Tools/Docker/Docker)
+- [Docker Network](https://notes.yxy.ninja/Tools/Docker/Docker-Network)
+- [Dynamic Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Dynamic-Port-Forwarding)
+- [Dynamic Routing Protocol](https://notes.yxy.ninja/Networking-Concepts/Dynamic-Routing-Protocol)
+- [Email Routing](https://notes.yxy.ninja/Networking-Concepts/Email-Routing)
+- [Email Security](https://notes.yxy.ninja/Security/Email-Security)
+- [End-to-End Service Access Troubleshooting](https://notes.yxy.ninja/Tools/End-to-End-Service-Access-Troubleshooting)
+- [Ethernet](https://notes.yxy.ninja/Networking-Protocol/Ethernet)
+- [Exponential Backoff](https://notes.yxy.ninja/Networking-MISC/Exponential-Backoff)
+- [File Sharing](https://notes.yxy.ninja/Networking-Concepts/File-Sharing)
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Head-of-Line Blocking (队头堵塞)](https://notes.yxy.ninja/Networking-Protocol/HTTP/Head-of-Line-Blocking-(队头堵塞))
+- [Host](https://notes.yxy.ninja/Networking-MISC/Host)
+- [Hostname](https://notes.yxy.ninja/Networking-Protocol/DNS/Hostname)
+- [Hot Standby Router Protocol](https://notes.yxy.ninja/Networking-Protocol/Hot-Standby-Router-Protocol)
+- [HTTP](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP)
+- [HTTP 1.0](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-1.0)
+- [HTTP 1.1](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-1.1)
+- [HTTP 2.0](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-2.0)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+- [HTTP Request](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Request)
+- [HTTP Request Methods](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Request-Methods)
+- [HTTP Response](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Response)
+- [HTTP Status Code](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Status-Code)
+- [ICMP](https://notes.yxy.ninja/Networking-Concepts/ICMP)
+- [Internet](https://notes.yxy.ninja/Networking-MISC/Internet)
+- [Internet Protocol (IP)](https://notes.yxy.ninja/Networking-Protocol/Internet-Protocol-(IP))
+- [IP Address](https://notes.yxy.ninja/Networking-Protocol/DNS/IP-Address)
+- [ISP](https://notes.yxy.ninja/Networking-MISC/ISP)
+- [Kubernetes Networking](https://notes.yxy.ninja/Networking-MISC/Kubernetes-Networking)
+- [Link-layer switches](https://notes.yxy.ninja/Networking-Devices/Link-layer-switches)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+- [MAC Address](https://notes.yxy.ninja/Networking-Concepts/MAC-Address)
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [NAT](https://notes.yxy.ninja/Networking-Concepts/NAT)
+- [Netfilter](https://notes.yxy.ninja/Networking-MISC/Netfilter)
+- [Network Bridge](https://notes.yxy.ninja/Networking-Devices/Network-Bridge)
+- [Network Firewall](https://notes.yxy.ninja/Networking-MISC/Network-Firewall)
+- [Network Interface](https://notes.yxy.ninja/Networking-Devices/Network-Interface)
+- [Network Object](https://notes.yxy.ninja/Networking-MISC/Network-Object)
+- [Network Operations](https://notes.yxy.ninja/Networking-MISC/Network-Operations)
+- [Network Packet](https://notes.yxy.ninja/Networking-MISC/Network-Packet)
+- [Network Port](https://notes.yxy.ninja/Networking-MISC/Network-Port)
+- [Network Protocol](https://notes.yxy.ninja/Networking-Protocol/Network-Protocol)
+- [Network Relay](https://notes.yxy.ninja/Networking-Concepts/Network-Relay)
+- [Network Router](https://notes.yxy.ninja/Networking-Devices/Network-Router)
+- [Network Switch](https://notes.yxy.ninja/Networking-Devices/Network-Switch)
+- [OpenWRT](https://notes.yxy.ninja/Networking-MISC/OpenWRT)
+- [OSI Model](https://notes.yxy.ninja/Networking-Concepts/OSI-Model)
+- [OSPF](https://notes.yxy.ninja/Networking-Concepts/OSPF)
+- [Port Channel](https://notes.yxy.ninja/Networking-Concepts/Port-Channel)
+- [QUIC](https://notes.yxy.ninja/Networking-Protocol/HTTP/QUIC)
+- [Real-time Web Communication](https://notes.yxy.ninja/Networking-Concepts/Real-time-Web-Communication)
+- [Remote Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Remote-Port-Forwarding)
+- [REST API](https://notes.yxy.ninja/Networking-MISC/REST-API)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SEO](https://notes.yxy.ninja/Networking-Concepts/SEO)
+- [Server Mirroring](https://notes.yxy.ninja/Networking-Concepts/Server-Mirroring)
+- [Shadowsocks](https://notes.yxy.ninja/Networking-MISC/Shadowsocks)
+- [SOCKS](https://notes.yxy.ninja/Networking-Protocol/SOCKS)
+- [Spanning Tree Protocol](https://notes.yxy.ninja/Networking-Protocol/Spanning-Tree-Protocol)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Subnet](https://notes.yxy.ninja/Networking-Concepts/Subnet)
+- [TCP](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP)
+- [TCP Connection](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP-Connection)
+- [TCP Handshake](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP-Handshake)
+- [TCP Tunneling](https://notes.yxy.ninja/Networking-Concepts/TCP-Tunneling)
+- [Tethering](https://notes.yxy.ninja/Networking-MISC/Tethering)
+- [TLS](https://notes.yxy.ninja/Networking-Protocol/TLS/TLS)
+- [TLS 1.2](https://notes.yxy.ninja/Networking-Protocol/TLS/TLS-1.2)
+- [Transmission rate](https://notes.yxy.ninja/Networking-MISC/Transmission-rate)
+- [TTL](https://notes.yxy.ninja/Networking-MISC/TTL)
+- [UDP](https://notes.yxy.ninja/Networking-Protocol/UDP)
+- [URL](https://notes.yxy.ninja/Networking-MISC/URL)
+- [VLAN](https://notes.yxy.ninja/Networking-Concepts/VLAN)
+- [VPN](https://notes.yxy.ninja/Networking-Protocol/VPN)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
+
+</details>
+
+<details>
+<summary><code>distributed_computing</code> · 5 notes</summary>
+
+- [Distributed Consensus](https://notes.yxy.ninja/Distributed-Computing/Consensus/Distributed-Consensus)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Raft Consensus Algorithm](https://notes.yxy.ninja/Distributed-Computing/Consensus/Raft-Consensus-Algorithm)
+- [Replicated State Machine](https://notes.yxy.ninja/Distributed-Computing/Consensus/Replicated-State-Machine)
+- [Span](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Span)
+
+</details>
+
+<details>
+<summary><code>curl</code> · 2 notes</summary>
+
+- [curl](https://notes.yxy.ninja/Bash/Networking/curl)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+
+</details>
+
+</details>
+
+<a id="operating-systems-hardware-hpc"></a>
+<details>
+<summary><strong>Operating Systems, Hardware & HPC</strong></summary>
+
+<details>
+<summary><code>OS</code> · 109 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Async IO](https://notes.yxy.ninja/OS/IO/Async-IO)
+- [Banker's Algorithm](https://notes.yxy.ninja/Algorithm/Banker's-Algorithm)
+- [Barrier (屏障)](https://notes.yxy.ninja/OS/Synchronization/Barrier-(屏障))
+- [Buffer](https://notes.yxy.ninja/OS/IO/Buffer)
+- [Busy Waiting](https://notes.yxy.ninja/OS/Synchronization/Busy-Waiting)
+- [Cache Locality](https://notes.yxy.ninja/OS/CPU/Cache-Locality)
+- [Computer Booting](https://notes.yxy.ninja/OS/Computer-Booting)
+- [Concurrency (并发)](https://notes.yxy.ninja/OS/Synchronization/Concurrency-(并发))
+- [Condition Variable (条件变量)](https://notes.yxy.ninja/OS/Synchronization/Condition-Variable-(条件变量))
+- [Containerisation](https://notes.yxy.ninja/OS/Containerisation)
+- [Context Switch](https://notes.yxy.ninja/OS/Process/Context-Switch)
+- [CPU Cache](https://notes.yxy.ninja/OS/CPU/CPU-Cache)
+- [CPU Scheduling Techniques](https://notes.yxy.ninja/OS/CPU/CPU-Scheduling-Techniques)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [CS2106 Introduction to Operating Systems](https://notes.yxy.ninja/NUS/CS2106-Introduction-to-Operating-Systems)
+- [CUDA](https://notes.yxy.ninja/Hpc/CUDA)
+- [CUDA Synchronization](https://notes.yxy.ninja/Hpc/CUDA-Synchronization)
+- [Database Comparison](https://notes.yxy.ninja/Database/Database-Comparison)
+- [Deadlock (死锁)](https://notes.yxy.ninja/OS/Synchronization/Deadlock-(死锁))
+- [Device Controller](https://notes.yxy.ninja/OS/IO/Device-Controller)
+- [Direct Memory Access (DMA)](https://notes.yxy.ninja/OS/IO/Direct-Memory-Access-(DMA))
+- [Docker Filesytem](https://notes.yxy.ninja/Tools/Docker/Docker-Filesytem)
+- [DuckDB](https://notes.yxy.ninja/Database/DuckDB)
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [File](https://notes.yxy.ninja/OS/File-System/File)
+- [File Compression](https://notes.yxy.ninja/OS/File-System/File-Compression)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [File System Link](https://notes.yxy.ninja/OS/File-System/File-System-Link)
+- [Filter File](https://notes.yxy.ninja/OS/File-System/Filter-File)
+- [Flash Memory](https://notes.yxy.ninja/OS/Memory/Flash-Memory)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [GIL](https://notes.yxy.ninja/Python/GIL)
+- [Global Interpreter Lock](https://notes.yxy.ninja/OS/Synchronization/Global-Interpreter-Lock)
+- [Goroutine](https://notes.yxy.ninja/OS/Thread/Goroutine)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+- [Hybrid Thread](https://notes.yxy.ninja/OS/Thread/Hybrid-Thread)
+- [Init System](https://notes.yxy.ninja/OS/Tools/Init-System)
+- [Inode](https://notes.yxy.ninja/OS/File-System/Inode)
+- [Inter-Process Communication](https://notes.yxy.ninja/OS/Process/Inter-Process-Communication)
+- [Interrupt Handler](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Handler)
+- [Interrupt Vector Table](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Vector-Table)
+- [Interrupts (中断)](https://notes.yxy.ninja/OS/Interrupt/Interrupts-(中断))
+- [IO Bus](https://notes.yxy.ninja/OS/IO/IO-Bus)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Kernel](https://notes.yxy.ninja/OS/Kernel)
+- [Kernel Space](https://notes.yxy.ninja/OS/Kernel-Space)
+- [Kernel Thread](https://notes.yxy.ninja/OS/Thread/Kernel-Thread)
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Library Call](https://notes.yxy.ninja/OS/System-Call/Library-Call)
+- [Linux Address Space](https://notes.yxy.ninja/OS/Process/Linux-Address-Space)
+- [Linux Kernel](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Linux-Kernel)
+- [Main Memory](https://notes.yxy.ninja/OS/Memory/Main-Memory)
+- [Memory Fragmentation](https://notes.yxy.ninja/OS/Memory/Memory-Fragmentation)
+- [Memory Page](https://notes.yxy.ninja/OS/Memory/Memory-Page)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [MMU](https://notes.yxy.ninja/OS/CPU/MMU)
+- [Multi-core Chip](https://notes.yxy.ninja/OS/CPU/Multi-core-Chip)
+- [Multi-processing](https://notes.yxy.ninja/OS/CPU/Multi-processing)
+- [Multi-Programming](https://notes.yxy.ninja/OS/CPU/Multi-Programming)
+- [Multi-threading](https://notes.yxy.ninja/OS/CPU/Multi-threading)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Mutex (互斥体)](https://notes.yxy.ninja/OS/Synchronization/Mutex-(互斥体))
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [OS](https://notes.yxy.ninja/OS/OS)
+- [OS System Program](https://notes.yxy.ninja/OS/OS-System-Program)
+- [Page Fault](https://notes.yxy.ninja/OS/Memory/Page-Fault)
+- [Page Table](https://notes.yxy.ninja/OS/Memory/Page-Table)
+- [Pipe (管道)](https://notes.yxy.ninja/OS/File-System/Pipe-(管道))
+- [POSIX](https://notes.yxy.ninja/OS/UNIX-vs-Linux/POSIX)
+- [Privilege Level](https://notes.yxy.ninja/OS/CPU/Privilege-Level)
+- [Process (进程)](https://notes.yxy.ninja/OS/Process/Process-(进程))
+- [Process Control Block (PCB)](https://notes.yxy.ninja/OS/Process/Process-Control-Block-(PCB))
+- [Process File](https://notes.yxy.ninja/OS/Process/Process-File)
+- [Process Hierarchy](https://notes.yxy.ninja/OS/Process/Process-Hierarchy)
+- [Process Operations](https://notes.yxy.ninja/OS/Process/Process-Operations)
+- [Process Scheduling](https://notes.yxy.ninja/OS/Process/Process-Scheduling)
+- [Producer Consumer Problem](https://notes.yxy.ninja/OS/Thread/Producer-Consumer-Problem)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Race Condition (竞态条件)](https://notes.yxy.ninja/OS/Synchronization/Race-Condition-(竞态条件))
+- [Register](https://notes.yxy.ninja/Computer-Organisation/Processor/Register)
+- [RISCV CLINT](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-CLINT)
+- [Rust Ownership](https://notes.yxy.ninja/Rust/Rust-Ownership)
+- [Segmentation Fault](https://notes.yxy.ninja/OS/Memory/Segmentation-Fault)
+- [Semaphore (信号量)](https://notes.yxy.ninja/OS/Synchronization/Semaphore-(信号量))
+- [Serial Communication](https://notes.yxy.ninja/OS/IO/Serial-Communication)
+- [Socket](https://notes.yxy.ninja/OS/Process/Socket)
+- [Stack](https://notes.yxy.ninja/Data-Structure/Stack)
+- [Swap Space](https://notes.yxy.ninja/OS/Memory/Swap-Space)
+- [Synchronisation (同步)](https://notes.yxy.ninja/OS/Synchronization/Synchronisation-(同步))
+- [System Call (系统调用)](https://notes.yxy.ninja/OS/System-Call/System-Call-(系统调用))
+- [Systemd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Systemd)
+- [Thread](https://notes.yxy.ninja/OS/Thread/Thread)
+- [Thread Pool](https://notes.yxy.ninja/OS/Thread/Thread-Pool)
+- [Time Slice](https://notes.yxy.ninja/OS/Process/Time-Slice)
+- [Timer Chip](https://notes.yxy.ninja/OS/Interrupt/Timer-Chip)
+- [TLB](https://notes.yxy.ninja/OS/CPU/TLB)
+- [Trap Interrupt (陷入)](https://notes.yxy.ninja/OS/Interrupt/Trap-Interrupt-(陷入))
+- [Unix](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Unix)
+- [User](https://notes.yxy.ninja/OS/Terminologies/User)
+- [User Space](https://notes.yxy.ninja/OS/User-Space)
+- [User Thread](https://notes.yxy.ninja/OS/Thread/User-Thread)
+- [VFS](https://notes.yxy.ninja/OS/File-System/VFS)
+- [Virtual Memory](https://notes.yxy.ninja/OS/Memory/Virtual-Memory)
+- [Virtualisation](https://notes.yxy.ninja/Virtualisation)
+
+</details>
+
+<details>
+<summary><code>os</code> · 4 notes</summary>
+
+- [CPU Load](https://notes.yxy.ninja/OS/CPU/CPU-Load)
+- [CUDA Memory](https://notes.yxy.ninja/Hpc/CUDA-Memory)
+- [Kernel Panic](https://notes.yxy.ninja/OS/Kernel-Panic)
+- [Memory Monitoring](https://notes.yxy.ninja/Devops/Memory-Monitoring)
+
+</details>
+
+<details>
+<summary><code>linux</code> · 13 notes</summary>
+
+- [Computer Booting](https://notes.yxy.ninja/OS/Computer-Booting)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Kernel](https://notes.yxy.ninja/OS/Kernel)
+- [Linux Kernel](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Linux-Kernel)
+- [Linux Namespace](https://notes.yxy.ninja/Bash/Linux-Namespace)
+- [POSIX](https://notes.yxy.ninja/OS/UNIX-vs-Linux/POSIX)
+- [Process (进程)](https://notes.yxy.ninja/OS/Process/Process-(进程))
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [User](https://notes.yxy.ninja/OS/Terminologies/User)
+
+</details>
+
+<details>
+<summary><code>macos</code> · 5 notes</summary>
+
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+
+</details>
+
+<details>
+<summary><code>computer_organisation</code> · 100 notes</summary>
+
+- [Adder](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Adder)
+- [ALU](https://notes.yxy.ninja/Computer-Organisation/Processor/ALU)
+- [AND](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/AND)
+- [Assembly language](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Assembly-language)
+- [Atomic Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Atomic-Instruction)
+- [Base 64 Encoding](https://notes.yxy.ninja/Computer-Organisation/Number-System/Base-64-Encoding)
+- [Bit Shifting](https://notes.yxy.ninja/Boolean-Algebra/Bit-Shifting)
+- [Bitmasking](https://notes.yxy.ninja/Boolean-Algebra/Bitmasking)
+- [Boolean Algebra](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Algebra)
+- [Boolean Function](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Function)
+- [Boolean Standard Form](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Standard-Form)
+- [Branch Prediction](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Branch-Prediction)
+- [Branch Prediction Strategies (Heuristics)](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Branch-Prediction-Strategies-(Heuristics))
+- [C Array](https://notes.yxy.ninja/C/C-Array)
+- [C Datatype](https://notes.yxy.ninja/C/C-Datatype)
+- [C Function](https://notes.yxy.ninja/C/C-Function)
+- [C String](https://notes.yxy.ninja/C/C-String)
+- [Cache Eviction](https://notes.yxy.ninja/System-Design/Cache/Cache-Eviction)
+- [Cache Locality](https://notes.yxy.ninja/OS/CPU/Cache-Locality)
+- [Cache Miss](https://notes.yxy.ninja/OS/CPU/Cache-Miss)
+- [Cache Strategy](https://notes.yxy.ninja/OS/CPU/Cache-Strategy)
+- [Character Encoding (字符编码）](https://notes.yxy.ninja/Computer-Organisation/Number-System/Character-Encoding-(字符编码）)
+- [Circuit Design](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Circuit-Design)
+- [CISC](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/CISC)
+- [Clock Oscillator](https://notes.yxy.ninja/Computer-Organisation/Processor/Clock-Oscillator)
+- [Combination Circuit](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Combination-Circuit)
+- [Complete Set of Logic](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Complete-Set-of-Logic)
+- [Computer Data Representation](https://notes.yxy.ninja/Computer-Organisation/Number-System/Computer-Data-Representation)
+- [Control Unit](https://notes.yxy.ninja/Computer-Organisation/Processor/Control-Unit)
+- [CPU](https://notes.yxy.ninja/Computer-Organisation/Processor/CPU)
+- [CPU Datapath](https://notes.yxy.ninja/Computer-Organisation/Processor/CPU-Datapath)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [Data Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Data-Latch)
+- [Decoder](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Decoder)
+- [Direct Mapped Cache](https://notes.yxy.ninja/OS/CPU/Direct-Mapped-Cache)
+- [Endianness](https://notes.yxy.ninja/Computer-Organisation/Number-System/Endianness)
+- [Flip-flop](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Flip-flop)
+- [Floating-Point Encoding (浮点数编码)](https://notes.yxy.ninja/Computer-Organisation/Number-System/Floating-Point-Encoding-(浮点数编码))
+- [FPGA](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/FPGA)
+- [Fully Associative Cache](https://notes.yxy.ninja/OS/CPU/Fully-Associative-Cache)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [GPU](https://notes.yxy.ninja/Computer-Organisation/Processor/GPU)
+- [Gray Code](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Gray-Code)
+- [Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction)
+- [Instruction Execution](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Execution)
+- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Set-Architecture-(ISA))
+- [Instruction Stages](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Instruction-Stages)
+- [Instruction-Level Parallelism](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Instruction-Level-Parallelism)
+- [Integer Encoding (数字编码)](https://notes.yxy.ninja/Computer-Organisation/Number-System/Integer-Encoding-(数字编码))
+- [ISA Addressing Mode](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Addressing-Mode)
+- [ISA Instruction Format](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Instruction-Format)
+- [ISA Storage Architecture](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Storage-Architecture)
+- [Karnaugh Map](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Karnaugh-Map)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Latch)
+- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Logic-Gates)
+- [Macro Expansion](https://notes.yxy.ninja/C/Macro-Expansion)
+- [Main Memory](https://notes.yxy.ninja/OS/Memory/Main-Memory)
+- [Maxterm](https://notes.yxy.ninja/Boolean-Algebra/Maxterm)
+- [Memory Address](https://notes.yxy.ninja/OS/Memory/Memory-Address)
+- [Minterm](https://notes.yxy.ninja/Boolean-Algebra/Minterm)
+- [MIPS](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS)
+- [MIPS ALU](https://notes.yxy.ninja/Computer-Organisation/Processor/MIPS-ALU)
+- [MIPS Control Flow](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Control-Flow)
+- [MIPS Control Unit](https://notes.yxy.ninja/Computer-Organisation/Processor/MIPS-Control-Unit)
+- [MIPS Data Memory](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Data-Memory)
+- [MIPS I-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-I-Type-Instruction)
+- [MIPS Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Instruction)
+- [MIPS J-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-J-Type-Instruction)
+- [MIPS Memory Access](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Memory-Access)
+- [MIPS R-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-R-Type-Instruction)
+- [MIPS Register](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Register)
+- [Multiplexer](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Multiplexer)
+- [NOT](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOT)
+- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/Number-System)
+- [Operand Forwarding](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Operand-Forwarding)
+- [Operation](https://notes.yxy.ninja/Terminologies/Operation)
+- [OR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/OR)
+- [Out-of-Order Execution](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Out-of-Order-Execution)
+- [Pipeline Branching](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Pipeline-Branching)
+- [Pipeline Flush](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Pipeline-Flush)
+- [Pipeline Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Pipeline-Hazard)
+- [Pipeline Stall](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Pipeline-Stall)
+- [Pipelining](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Pipelining)
+- [Pointer Arithmetic](https://notes.yxy.ninja/Programming/Pointer-Arithmetic)
+- [Programming Logic Array](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Programming-Logic-Array)
+- [Read-After-Write(RAW) Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Read-After-Write(RAW)-Hazard)
+- [Register](https://notes.yxy.ninja/Computer-Organisation/Processor/Register)
+- [RISC](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISC)
+- [RISCV CLINT](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-CLINT)
+- [RISCV Instructure](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-Instructure)
+- [RISCV Kernel Deep Dive](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-Kernel-Deep-Dive)
+- [ROM](https://notes.yxy.ninja/OS/Memory/ROM)
+- [Sequential Circuit](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Sequential-Circuit)
+- [Sequential Circuit Analysis](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Sequential-Circuit-Analysis)
+- [Set Associative Cache](https://notes.yxy.ninja/OS/CPU/Set-Associative-Cache)
+- [Set Reset Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Set-Reset-Latch)
+- [Specialised Processor](https://notes.yxy.ninja/Computer-Organisation/Processor/Specialised-Processor)
+- [Transistors (晶体管)](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Transistors-(晶体管))
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+
+</details>
+
+<details>
+<summary><code>hpc</code> · 5 notes</summary>
+
+- [CUDA](https://notes.yxy.ninja/Hpc/CUDA)
+- [CUDA Memory](https://notes.yxy.ninja/Hpc/CUDA-Memory)
+- [CUDA Synchronization](https://notes.yxy.ninja/Hpc/CUDA-Synchronization)
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+- [Slurm](https://notes.yxy.ninja/Hpc/Slurm)
+
+</details>
+
+<details>
+<summary><code>arduino</code> · 4 notes</summary>
+
+- [Clock Oscillator](https://notes.yxy.ninja/Computer-Organisation/Processor/Clock-Oscillator)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [ROM](https://notes.yxy.ninja/OS/Memory/ROM)
+- [Serial Communication](https://notes.yxy.ninja/OS/IO/Serial-Communication)
+
+</details>
+
+<details>
+<summary><code>opcode</code> · 1 note</summary>
+
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+
+</details>
+
+<details>
+<summary><code>boolean_algebra</code> · 11 notes</summary>
+
+- [AND](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/AND)
+- [Boolean Function](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Function)
+- [Boolean Standard Form](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Standard-Form)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Logic-Gates)
+- [Maxterm](https://notes.yxy.ninja/Boolean-Algebra/Maxterm)
+- [Minterm](https://notes.yxy.ninja/Boolean-Algebra/Minterm)
+- [NOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOR)
+- [NOT](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOT)
+- [OR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/OR)
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+
+</details>
+
+</details>
+
+<a id="programming-languages-paradigms"></a>
+<details>
+<summary><strong>Programming Languages & Paradigms</strong></summary>
+
+<details>
+<summary><code>c</code> · 17 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [C](https://notes.yxy.ninja/C/C)
+- [C Array](https://notes.yxy.ninja/C/C-Array)
+- [C Datatype](https://notes.yxy.ninja/C/C-Datatype)
+- [C Function](https://notes.yxy.ninja/C/C-Function)
+- [C Keywords](https://notes.yxy.ninja/C/C-Keywords)
+- [C Program Compilation](https://notes.yxy.ninja/C/C-Program-Compilation)
+- [C String](https://notes.yxy.ninja/C/C-String)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Interrupt Handler](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Handler)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Macro Expansion](https://notes.yxy.ninja/C/Macro-Expansion)
+- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/Number-System)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Pointer Arithmetic](https://notes.yxy.ninja/Programming/Pointer-Arithmetic)
+- [Semaphore (信号量)](https://notes.yxy.ninja/OS/Synchronization/Semaphore-(信号量))
+
+</details>
+
+<details>
+<summary><code>cpp</code> · 7 notes</summary>
+
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [CPP Notes](https://notes.yxy.ninja/C/CPP-Notes)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+
+</details>
+
+<details>
+<summary><code>java</code> · 41 notes</summary>
+
+- [Access Modifier](https://notes.yxy.ninja/Java/Access-Modifier)
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Boxing](https://notes.yxy.ninja/Java/Wrapper-Class/Boxing)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [CS2030S Programming Methodology II](https://notes.yxy.ninja/NUS/CS2030S-Programming-Methodology-II)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Dijkstra's Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Dijkstra's-Algorithm)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Dynamic Binding](https://notes.yxy.ninja/OOP/Dynamic-Binding)
+- [Exception](https://notes.yxy.ninja/Programming/Exception)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [Hash Map](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Map)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Java](https://notes.yxy.ninja/Java/Java)
+- [Java Comparison](https://notes.yxy.ninja/Java/Java-Comparison)
+- [Java Constructor](https://notes.yxy.ninja/Java/Java-Constructor)
+- [Java Keywords](https://notes.yxy.ninja/Java/Java-Keywords)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Java Optional](https://notes.yxy.ninja/Java/Java-Optional)
+- [Java Sorting](https://notes.yxy.ninja/Java/Java-Sorting)
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+- [Java Standard Library](https://notes.yxy.ninja/Java/Java-Standard-Library)
+- [Lazy Evaluation](https://notes.yxy.ninja/Functional/Lazy-Evaluation)
+- [Linked List](https://notes.yxy.ninja/Data-Structure/Linked-List)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [Method Overloading](https://notes.yxy.ninja/OOP/Method-Overloading)
+- [Method Overriding](https://notes.yxy.ninja/OOP/Method-Overriding)
+- [OOP](https://notes.yxy.ninja/OOP/OOP)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+- [Type Inference (类型推断)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Type-Inference-(类型推断))
+- [Variance](https://notes.yxy.ninja/OOP/Variance)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+- [Wrapper Class](https://notes.yxy.ninja/Java/Wrapper-Class/Wrapper-Class)
+
+</details>
+
+<details>
+<summary><code>python</code> · 20 notes</summary>
+
+- [AWS Lambda](https://notes.yxy.ninja/AWS/Compute/AWS-Lambda)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [GIL](https://notes.yxy.ninja/Python/GIL)
+- [Global Interpreter Lock](https://notes.yxy.ninja/OS/Synchronization/Global-Interpreter-Lock)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [HTTP](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Python Notes](https://notes.yxy.ninja/Programming/Python-Notes)
+- [Python Snippets for Markdown Processing](https://notes.yxy.ninja/Python-Snippets-for-Markdown-Processing)
+- [Python Toolset](https://notes.yxy.ninja/Tools/Python-Toolset)
+- [Pythonic Codes](https://notes.yxy.ninja/Programming/Pythonic-Codes)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [Union Find](https://notes.yxy.ninja/Data-Structure/Union-Find)
+
+</details>
+
+<details>
+<summary><code>rust</code> · 18 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Expression](https://notes.yxy.ninja/Programming/Expression)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Immutability](https://notes.yxy.ninja/Programming/Immutability)
+- [Important Rust Syntax](https://notes.yxy.ninja/Rust/Important-Rust-Syntax)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Rust](https://notes.yxy.ninja/Rust/Rust)
+- [Rust Borrowing](https://notes.yxy.ninja/Rust/Rust-Borrowing)
+- [Rust Ownership](https://notes.yxy.ninja/Rust/Rust-Ownership)
+- [Rust Pending Items](https://notes.yxy.ninja/Rust/Rust-Pending-Items)
+- [Rust Toolset](https://notes.yxy.ninja/Rust/Rust-Toolset)
+- [Segmentation Fault](https://notes.yxy.ninja/OS/Memory/Segmentation-Fault)
+- [Statement](https://notes.yxy.ninja/Programming/Statement)
+
+</details>
+
+<details>
+<summary><code>js</code> · 13 notes</summary>
+
+- [Array](https://notes.yxy.ninja/Data-Structure/Array)
+- [Async IO](https://notes.yxy.ninja/OS/IO/Async-IO)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [JS Toolset](https://notes.yxy.ninja/Tools/JS/JS-Toolset)
+- [JS Weird Syntax](https://notes.yxy.ninja/Tools/JS/JS-Weird-Syntax)
+- [Middleware (中间件)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Middleware-(中间件))
+- [Node.js](https://notes.yxy.ninja/Tools/JS/Node.js)
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Socket](https://notes.yxy.ninja/OS/Process/Socket)
+- [UDP](https://notes.yxy.ninja/Networking-Protocol/UDP)
+- [URL](https://notes.yxy.ninja/Networking-MISC/URL)
+
+</details>
+
+<details>
+<summary><code>go</code> · 7 notes</summary>
+
+- [Character Encoding (字符编码）](https://notes.yxy.ninja/Computer-Organisation/Number-System/Character-Encoding-(字符编码）)
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [Go](https://notes.yxy.ninja/Tools/Go)
+- [Goroutine](https://notes.yxy.ninja/OS/Thread/Goroutine)
+- [Mutex (互斥体)](https://notes.yxy.ninja/OS/Synchronization/Mutex-(互斥体))
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+
+</details>
+
+<details>
+<summary><code>functional</code> · 6 notes</summary>
+
+- [Closure](https://notes.yxy.ninja/Functional/Closure)
+- [Currying](https://notes.yxy.ninja/Functional/Currying)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Lazy Evaluation](https://notes.yxy.ninja/Functional/Lazy-Evaluation)
+- [Pure Function](https://notes.yxy.ninja/Functional/Pure-Function)
+
+</details>
+
+<details>
+<summary><code>OOP</code> · 18 notes</summary>
+
+- [Access Modifier](https://notes.yxy.ninja/Java/Access-Modifier)
+- [CS2030S Programming Methodology II](https://notes.yxy.ninja/NUS/CS2030S-Programming-Methodology-II)
+- [Dynamic Binding](https://notes.yxy.ninja/OOP/Dynamic-Binding)
+- [Encapsulation](https://notes.yxy.ninja/OOP/Encapsulation)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Inheritance](https://notes.yxy.ninja/OOP/Inheritance)
+- [Java Comparison](https://notes.yxy.ninja/Java/Java-Comparison)
+- [Java Constructor](https://notes.yxy.ninja/Java/Java-Constructor)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Method Overloading](https://notes.yxy.ninja/OOP/Method-Overloading)
+- [Method Overriding](https://notes.yxy.ninja/OOP/Method-Overriding)
+- [OOP](https://notes.yxy.ninja/OOP/OOP)
+- [OOP Compatibility](https://notes.yxy.ninja/OOP/OOP-Compatibility)
+- [OOP Method](https://notes.yxy.ninja/OOP/OOP-Method)
+- [Polymorphism](https://notes.yxy.ninja/OOP/Polymorphism)
+- [Subtyping](https://notes.yxy.ninja/OOP/Subtyping)
+- [Type Casting](https://notes.yxy.ninja/Programming/Type-Casting)
+- [Variance](https://notes.yxy.ninja/OOP/Variance)
+
+</details>
+
+<details>
+<summary><code>oop</code> · 1 note</summary>
+
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+
+</details>
+
+<details>
+<summary><code>programming</code> · 25 notes</summary>
+
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [Argument Pointer](https://notes.yxy.ninja/Programming/Argument-Pointer)
+- [Clean Code](https://notes.yxy.ninja/Programming/Clean-Code)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Exception](https://notes.yxy.ninja/Programming/Exception)
+- [Expression](https://notes.yxy.ninja/Programming/Expression)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Immutability](https://notes.yxy.ninja/Programming/Immutability)
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Pythonic Codes](https://notes.yxy.ninja/Programming/Pythonic-Codes)
+- [Statement](https://notes.yxy.ninja/Programming/Statement)
+- [String Interpolation](https://notes.yxy.ninja/Programming/String-Interpolation)
+- [Syntactic Scope](https://notes.yxy.ninja/Programming/Syntactic-Scope)
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+- [Type Safety](https://notes.yxy.ninja/Programming/Type-Safety)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+
+</details>
+
+</details>
+
+<a id="software-engineering-tooling"></a>
+<details>
+<summary><strong>Software Engineering & Tooling</strong></summary>
+
+<details>
+<summary><code>software_engineering</code> · 28 notes</summary>
+
+- [Abstraction](https://notes.yxy.ninja/Software-Engineering/Abstraction)
+- [Alert](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Alert)
+- [Application Performance Monitoring (APM)](https://notes.yxy.ninja/Software-Engineering/Monitoring/Application-Performance-Monitoring-(APM))
+- [Code Bundling](https://notes.yxy.ninja/Software-Engineering/Terminologies/Code-Bundling)
+- [Code Editor Setup](https://notes.yxy.ninja/Software-Engineering/Code-Editor-Setup)
+- [Code for Change](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Code-for-Change)
+- [Code Quality Assurance Tools](https://notes.yxy.ninja/Software-Engineering/Code-Quality-Assurance-Tools)
+- [Coding Convention](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Coding-Convention)
+- [Data Layer Abstraction](https://notes.yxy.ninja/Software-Engineering/Data-Layer-Abstraction)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Liskov Substitution Principle (LSP)](https://notes.yxy.ninja/Software-Engineering/SOLID-Design-Principles/Liskov-Substitution-Principle-(LSP))
+- [Middleware (中间件)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Middleware-(中间件))
+- [Mono Repos](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/Mono-Repos)
+- [Monorepo Build System](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/Monorepo-Build-System)
+- [nx](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/nx)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [ReactJS](https://notes.yxy.ninja/Tools/ReactJS)
+- [ReactJS Common Mistakes](https://notes.yxy.ninja/Tools/ReactJS-Common-Mistakes)
+- [Real User Monitoring](https://notes.yxy.ninja/Software-Engineering/Monitoring/Real-User-Monitoring)
+- [Sampling](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Sampling)
+- [Semantic Versioning](https://notes.yxy.ninja/Programming/Semantic-Versioning)
+- [Shim (垫片)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Shim-(垫片))
+- [Software Development Practices](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Software-Development-Practices)
+- [Span](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Span)
+- [Terminal](https://notes.yxy.ninja/Software-Engineering/Terminal)
+- [Trace](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Trace)
+- [Type Inference (类型推断)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Type-Inference-(类型推断))
+- [Type System](https://notes.yxy.ninja/Programming/Type-System)
+
+</details>
+
+<details>
+<summary><code>bash</code> · 26 notes</summary>
+
+- [Asymmetric Cryptography](https://notes.yxy.ninja/Security/Cryptography/Asymmetric-Cryptography)
+- [Atuin](https://notes.yxy.ninja/Bash/Atuin)
+- [Bash Script Parameter Handling](https://notes.yxy.ninja/Bash/Bash-Script-Parameter-Handling)
+- [Bash Scripting](https://notes.yxy.ninja/Bash/Bash-Scripting)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [File](https://notes.yxy.ninja/OS/File-System/File)
+- [File Compression](https://notes.yxy.ninja/OS/File-System/File-Compression)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [File System Link](https://notes.yxy.ninja/OS/File-System/File-System-Link)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [Inode](https://notes.yxy.ninja/OS/File-System/Inode)
+- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Set-Architecture-(ISA))
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [IP Address](https://notes.yxy.ninja/Networking-Protocol/DNS/IP-Address)
+- [jq](https://notes.yxy.ninja/Bash/Networking/jq)
+- [netstat](https://notes.yxy.ninja/Bash/Networking/netstat)
+- [Network Port](https://notes.yxy.ninja/Networking-MISC/Network-Port)
+- [scp](https://notes.yxy.ninja/Bash/Networking/scp)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Swap Space](https://notes.yxy.ninja/OS/Memory/Swap-Space)
+- [Systemd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Systemd)
+- [TCP](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP)
+- [Terminal](https://notes.yxy.ninja/Software-Engineering/Terminal)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+
+</details>
+
+<details>
+<summary><code>git</code> · 3 notes</summary>
+
+- [Git](https://notes.yxy.ninja/Tools/Git/Git)
+- [Git Hook](https://notes.yxy.ninja/Tools/Git/Git-Hook)
+- [Git Rebase](https://notes.yxy.ninja/Tools/Git/Git-Rebase)
+
+</details>
+
+<details>
+<summary><code>backend_dev</code> · 1 note</summary>
+
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+
+</details>
+
+<details>
+<summary><code>wechat</code> · 1 note</summary>
+
+- [WeChat API](https://notes.yxy.ninja/Tools/WeChat-API)
+
+</details>
+
+</details>
+
+<a id="algorithms-data-structures-math"></a>
+<details>
+<summary><strong>Algorithms, Data Structures & Math</strong></summary>
+
+<details>
+<summary><code>dsa</code> · 53 notes</summary>
+
+- [Abstract Data Type (ADT)](https://notes.yxy.ninja/Data-Structure/Abstract-Data-Type-(ADT))
+- [Algorithm](https://notes.yxy.ninja/Algorithm/Algorithm)
+- [Algorithm Complexity Analysis](https://notes.yxy.ninja/Algorithm/Algorithm-Complexity-Analysis)
+- [Algorithm Content Page](https://notes.yxy.ninja/Algorithm/Algorithm-Content-Page)
+- [Array](https://notes.yxy.ninja/Data-Structure/Array)
+- [AVL Tree](https://notes.yxy.ninja/Data-Structure/Tree/AVL-Tree)
+- [Backtracking](https://notes.yxy.ninja/Algorithm/Recursion/Backtracking)
+- [Banker's Algorithm](https://notes.yxy.ninja/Algorithm/Banker's-Algorithm)
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+- [BFS](https://notes.yxy.ninja/Algorithm/BFS)
+- [Binary Search](https://notes.yxy.ninja/Algorithm/Binary-Search)
+- [Binary Search in Rotated Sorted Array](https://notes.yxy.ninja/Algorithm/Binary-Search-in-Rotated-Sorted-Array)
+- [Binary Search Tree (二叉搜索树)](https://notes.yxy.ninja/Data-Structure/Tree/Binary-Search-Tree-(二叉搜索树))
+- [Binary Tree](https://notes.yxy.ninja/Data-Structure/Tree/Binary-Tree)
+- [Binomial Coefficient](https://notes.yxy.ninja/Discrete-Math/We-Count/Binomial-Coefficient)
+- [Combinatorial Optimisation](https://notes.yxy.ninja/Algorithm/Optimisation/Combinatorial-Optimisation)
+- [Complete Binary Tree (完全二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Complete-Binary-Tree-(完全二叉树))
+- [CS2040S Data Structures and Algorithms](https://notes.yxy.ninja/NUS/CS2040S-Data-Structures-and-Algorithms)
+- [Data Structure](https://notes.yxy.ninja/Data-Structure/Data-Structure)
+- [Data Structure Content Page](https://notes.yxy.ninja/Data-Structure/Data-Structure-Content-Page)
+- [Deque](https://notes.yxy.ninja/Data-Structure/Deque)
+- [DFS](https://notes.yxy.ninja/Algorithm/Recursion/DFS)
+- [DFS vs BFS vs Backtracking](https://notes.yxy.ninja/Algorithm/DFS-vs-BFS-vs-Backtracking)
+- [Dijkstra's Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Dijkstra's-Algorithm)
+- [DSA Algorithm Template](https://notes.yxy.ninja/Templates/DSA-Algorithm-Template)
+- [Dynamic Programming](https://notes.yxy.ninja/Algorithm/Optimisation/Dynamic-Programming)
+- [Full Binary Tree (完满二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Full-Binary-Tree-(完满二叉树))
+- [Genetic Algorithms](https://notes.yxy.ninja/Algorithm/Genetic-Algorithms)
+- [Graph](https://notes.yxy.ninja/Data-Structure/Graph)
+- [Greedy Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Greedy-Algorithm)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [Hash Function](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Function)
+- [Hash Map](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Map)
+- [Heap](https://notes.yxy.ninja/Data-Structure/Heap)
+- [Interval](https://notes.yxy.ninja/Algorithm/terminologies/Interval)
+- [Kadane's algorithm](https://notes.yxy.ninja/Algorithm/Kadane's-algorithm)
+- [Kahn's Algorithm](https://notes.yxy.ninja/Algorithm/Kahn's-Algorithm)
+- [Linked List](https://notes.yxy.ninja/Data-Structure/Linked-List)
+- [Memoization](https://notes.yxy.ninja/Algorithm/Optimisation/Memoization)
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+- [Perfect Binary Tree (完美二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Perfect-Binary-Tree-(完美二叉树))
+- [Prefix Sum (前缀和)](https://notes.yxy.ninja/Algorithm/Prefix-Sum-(前缀和))
+- [Priority Queue](https://notes.yxy.ninja/Data-Structure/Priority-Queue)
+- [Pseudo-Random Number Generation](https://notes.yxy.ninja/Algorithm/Pseudo-Random-Number-Generation)
+- [Queue](https://notes.yxy.ninja/Data-Structure/Queue)
+- [Quick Select](https://notes.yxy.ninja/Algorithm/Quick-Select)
+- [Recursion](https://notes.yxy.ninja/Algorithm/Recursion/Recursion)
+- [Sorting](https://notes.yxy.ninja/Algorithm/Recursion/Sorting)
+- [Stack](https://notes.yxy.ninja/Data-Structure/Stack)
+- [Sub-Sequence](https://notes.yxy.ninja/Algorithm/terminologies/Sub-Sequence)
+- [Tree](https://notes.yxy.ninja/Data-Structure/Tree/Tree)
+- [Two Pointers (双指针)](https://notes.yxy.ninja/Algorithm/Two-Pointers-(双指针))
+- [Union Find](https://notes.yxy.ninja/Data-Structure/Union-Find)
+
+</details>
+
+<details>
+<summary><code>cp</code> · 28 notes</summary>
+
+- [(CodeForces) A Balanced Problem set?](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-A-Balanced-Problem-set?)
+- [(CodeForces) All The Same](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-All-The-Same)
+- [(CodeForces) Almost Ternary Matrix](https://notes.yxy.ninja/cp/dynamic_programming/(CodeForces)-Almost-Ternary-Matrix)
+- [(CodeForces) Divisibility](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Divisibility)
+- [(CodeForces) Equalize](https://notes.yxy.ninja/cp/greedy/(CodeForces)-Equalize)
+- [(CodeForces) Forming Triangles](https://notes.yxy.ninja/cp/combinatorics/(CodeForces)-Forming-Triangles)
+- [(CodeForces) Minimize Inversions](https://notes.yxy.ninja/cp/greedy/(CodeForces)-Minimize-Inversions)
+- [(CodeForces) Non-coprime Split](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Non-coprime-Split)
+- [(CodeForces) Partitioning the Array](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Partitioning-the-Array)
+- [(CodeForces) Rectangle Cutting](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Rectangle-Cutting)
+- [(CodeForces) Rectangular Game](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Rectangular-Game)
+- [Closest Cities](https://notes.yxy.ninja/cp/prefix_sum/Closest-Cities)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [Container With Most Water](https://notes.yxy.ninja/cp/greedy/Container-With-Most-Water)
+- [cp](https://notes.yxy.ninja/Templates/cp)
+- [CP Tips](https://notes.yxy.ninja/cp/CP-Tips)
+- [Leetcode - House Robber](https://notes.yxy.ninja/cp/dynamic_programming/Leetcode---House-Robber)
+- [Leetcode - Product of Array Except Self](https://notes.yxy.ninja/cp/prefix_sum/Leetcode---Product-of-Array-Except-Self)
+- [LRU](https://notes.yxy.ninja/cp/data_structure/LRU)
+- [Next Permutation](https://notes.yxy.ninja/cp/greedy/Next-Permutation)
+- [Pasha and Stick](https://notes.yxy.ninja/cp/combinatorics/Pasha-and-Stick)
+- [Pending CP Questions](https://notes.yxy.ninja/cp/Pending-CP-Questions)
+- [Romantic Glasses](https://notes.yxy.ninja/cp/prefix_sum/Romantic-Glasses)
+- [Square Difference](https://notes.yxy.ninja/cp/Square-Difference)
+- [Valid Sudoku](https://notes.yxy.ninja/cp/data_structure/Valid-Sudoku)
+- [Word Break](https://notes.yxy.ninja/cp/dynamic_programming/Word-Break)
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+- [YetnotherrokenKeoard](https://notes.yxy.ninja/cp/data_structure/YetnotherrokenKeoard)
+
+</details>
+
+<details>
+<summary><code>problem_solving</code> · 2 notes</summary>
+
+- [Problem Solving](https://notes.yxy.ninja/Problem-solving/Problem-Solving)
+- [Problem Solving Sample Problem](https://notes.yxy.ninja/Problem-solving/Problem-Solving-Sample-Problem)
+
+</details>
+
+<details>
+<summary><code>math</code> · 3 notes</summary>
+
+- [Fermi Problem](https://notes.yxy.ninja/Math/Fermi-Problem)
+- [Sequence](https://notes.yxy.ninja/Math/Sequence)
+- [Series](https://notes.yxy.ninja/Math/Series)
+
+</details>
+
+<details>
+<summary><code>discrete_math</code> · 44 notes</summary>
+
+- [Cartesian Product](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Cartesian-Product)
+- [Combination](https://notes.yxy.ninja/Discrete-Math/We-Count/Combination)
+- [Combinatorics](https://notes.yxy.ninja/Discrete-Math/We-Count/Combinatorics)
+- [Conditional Statement](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Conditional-Statement)
+- [Counting](https://notes.yxy.ninja/Discrete-Math/We-Count/Counting)
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Deductive Reasoning (演繹推理)](https://notes.yxy.ninja/Discrete-Math/Deductive-Reasoning-(演繹推理))
+- [Direct Proof](https://notes.yxy.ninja/Discrete-Math/Direct-Proof)
+- [Discrete Geometry](https://notes.yxy.ninja/Discrete-Math/Discrete-Geometry)
+- [Discrete Math](https://notes.yxy.ninja/Discrete-Math/Discrete-Math)
+- [Divisibility (可除性)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Divisibility-(可除性))
+- [Empty Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Empty-Set)
+- [Equivalence Relation](https://notes.yxy.ninja/Discrete-Math/Equivalence-Relation)
+- [Existential Statement](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Existential-Statement)
+- [Fallacy](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Fallacy)
+- [Graph](https://notes.yxy.ninja/Data-Structure/Graph)
+- [Indirect Proof](https://notes.yxy.ninja/Discrete-Math/Indirect-Proof)
+- [Mathematical Argument](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Mathematical-Argument)
+- [Mathematical Function](https://notes.yxy.ninja/Discrete-Math/Mathematical-Function)
+- [Mathematical Proof](https://notes.yxy.ninja/Discrete-Math/Mathematical-Proof)
+- [Mathematical Statement](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Mathematical-Statement)
+- [Mutually Disjoin Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Mutually-Disjoin-Set)
+- [Ordered Pair](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Ordered-Pair)
+- [Partial Order](https://notes.yxy.ninja/Discrete-Math/Partial-Order)
+- [Permutation](https://notes.yxy.ninja/Discrete-Math/We-Count/Permutation)
+- [Power Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Power-Set)
+- [Predicate](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Predicate)
+- [Properties of Integer](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Properties-of-Integer)
+- [Propositional Logic](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Propositional-Logic)
+- [Quantified Rule of Inference](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Quantified-Rule-of-Inference)
+- [Quantifier](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Quantifier)
+- [Rational Number](https://notes.yxy.ninja/Number-Theory/Rational-Number)
+- [Relation](https://notes.yxy.ninja/Discrete-Math/Relation)
+- [Relation Composition](https://notes.yxy.ninja/Discrete-Math/Relation-Composition)
+- [Relation Property](https://notes.yxy.ninja/Discrete-Math/Relation-Property)
+- [Rule of Inference (推理规则)](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Rule-of-Inference-(推理规则))
+- [Sequence](https://notes.yxy.ninja/Math/Sequence)
+- [Series](https://notes.yxy.ninja/Math/Series)
+- [Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set)
+- [Set Equality](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Equality)
+- [Set Notation](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Notation)
+- [Set Partition](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Partition)
+- [Set Theorem](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Theorem)
+- [Subset](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Subset)
+
+</details>
+
+<details>
+<summary><code>number_theory</code> · 10 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Divisibility (可除性)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Divisibility-(可除性))
+- [Factor](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Factor)
+- [GCD](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/GCD)
+- [Integer (整数)](https://notes.yxy.ninja/Number-Theory/Integer-(整数))
+- [Modulo](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Modulo)
+- [Prime Number (质数)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Prime-Number-(质数))
+- [Properties of Integer](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Properties-of-Integer)
+- [Rational Number](https://notes.yxy.ninja/Number-Theory/Rational-Number)
+- [Real Number](https://notes.yxy.ninja/Number-Theory/Real-Number)
+
+</details>
+
+<details>
+<summary><code>probability</code> · 3 notes</summary>
+
+- [Binomial Coefficient](https://notes.yxy.ninja/Discrete-Math/We-Count/Binomial-Coefficient)
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Probability Problems](https://notes.yxy.ninja/Probability/Probability-Problems)
+
+</details>
+
+<details>
+<summary><code>geometry</code> · 2 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Discrete Geometry](https://notes.yxy.ninja/Discrete-Math/Discrete-Geometry)
+
+</details>
+
+<details>
+<summary><code>calculus</code> · 1 note</summary>
+
+- [Relation](https://notes.yxy.ninja/Discrete-Math/Relation)
+
+</details>
+
+<details>
+<summary><code>graph</code> · 3 notes</summary>
+
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+- [DFS vs BFS vs Backtracking](https://notes.yxy.ninja/Algorithm/DFS-vs-BFS-vs-Backtracking)
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+
+</details>
+
+<details>
+<summary><code>shortest-path</code> · 1 note</summary>
+
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+
+</details>
+
+<details>
+<summary><code>optimization</code> · 1 note</summary>
+
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+
+</details>
+
+</details>
+
+<a id="data-management"></a>
+<details>
+<summary><strong>Data Management</strong></summary>
+
+<details>
+<summary><code>database</code> · 11 notes</summary>
+
+- [ACID Transactions](https://notes.yxy.ninja/Database/ACID-Transactions)
+- [Database](https://notes.yxy.ninja/Database/Database)
+- [Database Collation](https://notes.yxy.ninja/Database/Database-Collation)
+- [Database Comparison](https://notes.yxy.ninja/Database/Database-Comparison)
+- [Database Indexing](https://notes.yxy.ninja/Database/Database-Indexing)
+- [Database Paradigms](https://notes.yxy.ninja/Database/Database-Paradigms)
+- [Database Partitioning](https://notes.yxy.ninja/Database/Database-Partitioning)
+- [Database Search](https://notes.yxy.ninja/Database/Database-Search)
+- [DuckDB](https://notes.yxy.ninja/Database/DuckDB)
+- [MySQL](https://notes.yxy.ninja/Database/MySQL)
+- [SQL](https://notes.yxy.ninja/Database/SQL)
+
+</details>
+
+<details>
+<summary><code>sql</code> · 2 notes</summary>
+
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+
+</details>
+
+<details>
+<summary><code>postgres</code> · 1 note</summary>
+
+- [Postgres](https://notes.yxy.ninja/Database/Postgres)
+
+</details>
+
+</details>
+
+<a id="security-identity"></a>
+<details>
+<summary><strong>Security & Identity</strong></summary>
+
+<details>
+<summary><code>security</code> · 33 notes</summary>
+
+- [Access Control List](https://notes.yxy.ninja/Security/Access-Control-List)
+- [Asymmetric Cryptography](https://notes.yxy.ninja/Security/Cryptography/Asymmetric-Cryptography)
+- [Authentication](https://notes.yxy.ninja/Security/Authentication/Authentication)
+- [Authorisation](https://notes.yxy.ninja/Security/Authorisation/Authorisation)
+- [AWS ACL](https://notes.yxy.ninja/AWS/Security/AWS-ACL)
+- [Ciphertext (密文)](https://notes.yxy.ninja/Security/Terminologies/Ciphertext-(密文))
+- [Cloudflare Access](https://notes.yxy.ninja/Security/Authentication/Cloudflare-Access)
+- [Common Security Attacks](https://notes.yxy.ninja/Security/Common-Security-Attacks)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [Cookie](https://notes.yxy.ninja/Security/Authentication/Cookie)
+- [Digital Signature](https://notes.yxy.ninja/Security/Cryptography/Digital-Signature)
+- [Dynamic Secrets](https://notes.yxy.ninja/Security/Dynamic-Secrets)
+- [Email Security](https://notes.yxy.ninja/Security/Email-Security)
+- [Encryption](https://notes.yxy.ninja/Security/Encryption)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [Hash Function](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Function)
+- [HMAC (Hash-Based Message Authentication Code)](https://notes.yxy.ninja/Security/Cryptography/HMAC-(Hash-Based-Message-Authentication-Code))
+- [HTTP Basic Authentication](https://notes.yxy.ninja/Security/Authentication/HTTP-Basic-Authentication)
+- [JWT](https://notes.yxy.ninja/Security/Authentication/JWT)
+- [Key's Randomart Image](https://notes.yxy.ninja/Security/Terminologies/Key's-Randomart-Image)
+- [OAuth 2.0](https://notes.yxy.ninja/Security/Authorisation/OAuth-2.0)
+- [OIDC Authentication](https://notes.yxy.ninja/Security/Authentication/OIDC-Authentication)
+- [PEM (Privacy Enhanced Mail)](https://notes.yxy.ninja/Security/PEM-(Privacy-Enhanced-Mail))
+- [Salting](https://notes.yxy.ninja/Security/Cryptography/Salting)
+- [Security Group](https://notes.yxy.ninja/AWS/Security/Security-Group)
+- [Session-Cookie Authentication](https://notes.yxy.ninja/Security/Authentication/Session-Cookie-Authentication)
+- [Shift-left Security](https://notes.yxy.ninja/Security/Terminologies/Shift-left-Security)
+- [Single Sign-On (SSO)](https://notes.yxy.ninja/Security/Authentication/Single-Sign-On-(SSO))
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Symmetric Encryption](https://notes.yxy.ninja/Security/Cryptography/Symmetric-Encryption)
+- [Token-Based Authentication](https://notes.yxy.ninja/Security/Authentication/Token-Based-Authentication)
+- [User Principle Name](https://notes.yxy.ninja/Security/Authentication/User-Principle-Name)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
+
+</details>
+
+<details>
+<summary><code>binance</code> · 16 notes</summary>
+
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [Data Layer Abstraction](https://notes.yxy.ninja/Software-Engineering/Data-Layer-Abstraction)
+- [Database Collation](https://notes.yxy.ninja/Database/Database-Collation)
+- [Database Indexing](https://notes.yxy.ninja/Database/Database-Indexing)
+- [Database Search](https://notes.yxy.ninja/Database/Database-Search)
+- [Java Optional](https://notes.yxy.ninja/Java/Java-Optional)
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Observability](https://notes.yxy.ninja/Devops/Observability)
+- [Prometheus](https://notes.yxy.ninja/Devops/Prometheus)
+- [Prometheus On Macos](https://notes.yxy.ninja/Devops/Prometheus-On-Macos)
+- [PromQL](https://notes.yxy.ninja/Devops/PromQL)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+
+</details>
+
+</details>
+
+<a id="career-finance-academia"></a>
+<details>
+<summary><strong>Career, Finance & Academia</strong></summary>
+
+<details>
+<summary><code>career</code> · 1 note</summary>
+
+- [Negotiation](https://notes.yxy.ninja/Career/Negotiation)
+
+</details>
+
+<details>
+<summary><code>interview</code> · 1 note</summary>
+
+- [Mock Interviews](https://notes.yxy.ninja/Interview/Mock-Interviews)
+
+</details>
+
+<details>
+<summary><code>finance</code> · 7 notes</summary>
+
+- [Affiliate Business](https://notes.yxy.ninja/Finance/Affiliate-Business)
+- [Card Strategy as a Student](https://notes.yxy.ninja/Finance/Card-Strategy-as-a-Student)
+- [Credit Card](https://notes.yxy.ninja/Finance/Credit-Card)
+- [Income Tax Relief](https://notes.yxy.ninja/Finance/Income-Tax-Relief)
+- [Market Liquidity](https://notes.yxy.ninja/Finance/Market-Liquidity)
+- [Market Maker](https://notes.yxy.ninja/Finance/Market-Maker)
+- [Negotiation](https://notes.yxy.ninja/Career/Negotiation)
+
+</details>
+
+<details>
+<summary><code>nus</code> · 4 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [CS2040S Data Structures and Algorithms](https://notes.yxy.ninja/NUS/CS2040S-Data-Structures-and-Algorithms)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [CS2106 Introduction to Operating Systems](https://notes.yxy.ninja/NUS/CS2106-Introduction-to-Operating-Systems)
+
+</details>
+
+<details>
+<summary><code>cs2030s</code> · 4 notes</summary>
+
+- [Code for Change](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Code-for-Change)
+- [Coding Convention](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Coding-Convention)
+- [Software Development Practices](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Software-Development-Practices)
+- [Type System](https://notes.yxy.ninja/Programming/Type-System)
+
+</details>
+
+<details>
+<summary><code>hacktron</code> · 2 notes</summary>
+
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+
+</details>
+
+</details>
+
+<a id="ai-emerging-tech"></a>
+<details>
+<summary><strong>AI & Emerging Tech</strong></summary>
+
+<details>
+<summary><code>ai</code> · 1 note</summary>
+
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+
+</details>
+
+</details>
+
+<a id="visual-library"></a>
+<details>
+<summary><strong>Visual Library</strong></summary>
+
+<details>
+<summary><code>excalidraw</code> · 3 notes</summary>
+
+- [base64_encoding.excalidraw](https://notes.yxy.ninja/Computer-Organisation/excalidraw/base64_encoding.excalidraw)
+- [Container With Most Water.excalidraw](https://notes.yxy.ninja/cp/greedy/excalidraw/Container-With-Most-Water.excalidraw)
+- [World Break.excalidraw](https://notes.yxy.ninja/cp/dynamic_programming/excalidraw/World-Break.excalidraw)
+
+</details>
+
+</details>

--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 | [Algorithms, Data Structures & Math](#algorithms-data-structures-math) | Problem-solving playbooks, math fundamentals, and contest prep |
 | [Data Management](#data-management) | Relational theory, storage engines, and SQL patterns |
 | [Security & Identity](#security-identity) | Security architecture, authentication, and enterprise trust |
+| [Past Job Experience](#past-job-experience) | Highlights from Binance, Hacktron, and Opcode workstreams |
 | [Career, Finance & Academia](#career-finance-academia) | Professional growth, financial literacy, and academic references |
+| [NUS](#nus) | School coursework, module notes, and academic projects |
 | [AI & Emerging Tech](#ai-emerging-tech) | High-performance AI workloads and modern ML infrastructure |
-| [Visual Library](#visual-library) | Hand-crafted Excalidraw diagrams and visual aids |
 
 <a id="architecture-cloud-operations"></a>
 <details>
@@ -644,13 +645,6 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 - [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
 - [ROM](https://notes.yxy.ninja/OS/Memory/ROM)
 - [Serial Communication](https://notes.yxy.ninja/OS/IO/Serial-Communication)
-
-</details>
-
-<details>
-<summary><code>opcode</code> · 1 note</summary>
-
-- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
 
 </details>
 
@@ -1323,6 +1317,12 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+</details>
+
+<a id="past-job-experience"></a>
+<details>
+<summary><strong>Past Job Experience</strong></summary>
+
 <details>
 <summary><code>binance</code> · 16 notes</summary>
 
@@ -1345,9 +1345,21 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+<details>
+<summary><code>hacktron</code> · 2 notes</summary>
+
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+
 </details>
 
-<a id="career-finance-academia"></a>
+<details>
+<summary><code>opcode</code> · 1 note</summary>
+
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+
+</details>
+
 <details>
 <summary><strong>Career, Finance & Academia</strong></summary>
 
@@ -1378,6 +1390,12 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+</details>
+
+<a id="nus"></a>
+<details>
+<summary><strong>NUS</strong></summary>
+
 <details>
 <summary><code>nus</code> · 4 notes</summary>
 
@@ -1398,14 +1416,6 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<details>
-<summary><code>hacktron</code> · 2 notes</summary>
-
-- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
-- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
-
-</details>
-
 </details>
 
 <a id="ai-emerging-tech"></a>
@@ -1421,17 +1431,3 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="visual-library"></a>
-<details>
-<summary><strong>Visual Library</strong></summary>
-
-<details>
-<summary><code>excalidraw</code> · 3 notes</summary>
-
-- [base64_encoding.excalidraw](https://notes.yxy.ninja/Computer-Organisation/excalidraw/base64_encoding.excalidraw)
-- [Container With Most Water.excalidraw](https://notes.yxy.ninja/cp/greedy/excalidraw/Container-With-Most-Water.excalidraw)
-- [World Break.excalidraw](https://notes.yxy.ninja/cp/dynamic_programming/excalidraw/World-Break.excalidraw)
-
-</details>
-
-</details>

--- a/README.md
+++ b/README.md
@@ -53,7 +53,24 @@ I am planning to work on my notes daily for the next **10 years**, building a se
 
 ## Notes Navigator 🧭
 
-### 🏭 System Design
+Use the quick index below to jump straight to the topics you care about, then expand any section to explore the related notes.
+
+| Domain | Quick Jump |
+| --- | --- |
+| 🏭 [System Design](#system-design) | Scalability foundations, service roles, and architecture blueprints |
+| 💻 [Operating System](#operating-system) | CPU, memory, processes, interrupts, and more |
+| 🖥️ [Computer Organisation](#computer-organisation) | ISA families, pipelines, and digital logic |
+| 🧠 [Data Structure & Algorithm](#data-structure--algorithm) | Core patterns for solving problems |
+| 👩‍💻 [Competitive Programming](#competitive-programming) | Templates and topic-based practice guides |
+| ➕ [Math](#math) | Number theory and discrete mathematics refreshers |
+| 🔤 [Programming Language](#programming-language) | Language-specific idioms and best practices |
+| 🛠️ [Software Engineering](#software-engineering) | Engineering principles, tooling, and operations |
+| 🕸️ [Networking](#networking) | Protocol fundamentals and revision notes |
+
+<a id="system-design"></a>
+<details open>
+<summary><strong>🏭 System Design</strong></summary>
+
 - [Basis](https://notes.yxy.ninja/System-Design/)
 - [Proxy](https://notes.yxy.ninja/System-Design/Proxy/)
 - [Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/)
@@ -63,57 +80,52 @@ I am planning to work on my notes daily for the next **10 years**, building a se
 - [Monitoring](https://notes.yxy.ninja/System-Design/Monitoring/)
 - [Architecture](https://notes.yxy.ninja/System-Design/Architectures/)
 
+<a id="operating-system"></a>
+<details>
+<summary><strong>💻 Operating System</strong></summary>
 
-### 💻 Operating System
 - [Intro](https://notes.yxy.ninja/OS/)
-</br>
-
 - [CPU](https://notes.yxy.ninja/OS/CPU/)
 - [File System](https://notes.yxy.ninja/OS/File-System/)
 - [IO](https://notes.yxy.ninja/OS/IO/)
 - [Memory](https://notes.yxy.ninja/OS/Memory/)
-</br>
-
 - [Process (进程)](https://notes.yxy.ninja/OS/Process/)
 - [Thread (线程)](https://notes.yxy.ninja/OS/Thread/)
 - [Synchronization (同步)](https://notes.yxy.ninja/OS/Synchronization/)
-</br>
-
 - [Interrupt (中断)](https://notes.yxy.ninja/OS/Interrupt/)
 - [System-Calls (系统调用)](https://notes.yxy.ninja/OS/System-Call/)
-</br>
-
 - [UNIX vs Linux](https://notes.yxy.ninja/OS/UNIX-vs-Linux/)
 - [MISC](https://notes.yxy.ninja/OS/Terminologies/)
 
+<a id="computer-organisation"></a>
+<details>
+<summary><strong>🖥️ Computer Organisation</strong></summary>
 
-### 🖥️ Computer Organisation 
 - [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/)
 - [Processor](https://notes.yxy.ninja/Computer-Organisation/Processor/)
-</br>
-
 - [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/)
 - [MIPS](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/)
 - [RISCV](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/)
-</br>
-
 - [Pipeline](https://notes.yxy.ninja/Computer-Organisation/Pipeline/)
 - [Pipeline Branching](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/)
 - [Pipeline Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/)
-</br>
-
 - [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/)
 - [Combination Circuit](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/)
 - [Sequential Circuit](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/)
 - [Circuit Design](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/)
-</br>
 
-### 🧠 Data Structure & Algorithm
+<a id="data-structure--algorithm"></a>
+<details>
+<summary><strong>🧠 Data Structure & Algorithm</strong></summary>
+
 - [Problem Solving Tricks](https://notes.yxy.ninja/tags/problem_solving)
 - [Algorithm](https://notes.yxy.ninja/Algorithm/Algorithm-Content-Page)
 - [Data Structure](https://notes.yxy.ninja/Data-Structure/Data-Structure-Content-Page)
 
-### 👩‍💻 Competitive Programming
+<a id="competitive-programming"></a>
+<details>
+<summary><strong>👩‍💻 Competitive Programming</strong></summary>
+
 - [Code Template](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
 - [Data Structure](https://notes.yxy.ninja/cp/data_structure/)
 - [Prefix Sum](https://notes.yxy.ninja/cp/prefix_sum/)
@@ -122,25 +134,29 @@ I am planning to work on my notes daily for the next **10 years**, building a se
 - [Number Theory](https://notes.yxy.ninja/cp/number_theory/)
 - [Combinatorics](https://notes.yxy.ninja/cp/combinatorics/)
 
+<a id="math"></a>
+<details>
+<summary><strong>➕ Math</strong></summary>
 
-### ➕ Math
 - [Number Theory Basis](https://notes.yxy.ninja/tags/number_theory)
 - [Divisibility & Primes](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/)
-</br>
-
 - [Discrete Math](https://notes.yxy.ninja/tags/discrete_math)
 - [Boolean Algebra](https://notes.yxy.ninja/tags/boolean_algebra)
 
+<a id="programming-language"></a>
+<details>
+<summary><strong>🔤 Programming Language</strong></summary>
 
-### 🔤 Programming Language
 - [C](https://notes.yxy.ninja/tags/c)
 - [Python](https://notes.yxy.ninja/tags/python)
 - [Rust](https://notes.yxy.ninja/tags/rust)
 - [Java](https://notes.yxy.ninja/tags/java)
 - [Javascript](https://notes.yxy.ninja/tags/js)
 
+<a id="software-engineering"></a>
+<details>
+<summary><strong>🛠️ Software Engineering</strong></summary>
 
-### 🛠️ Software Engineering 
 - [Software Engineering Theories](https://notes.yxy.ninja/tags/software_engineering)
 - [Amazon Web Services](https://notes.yxy.ninja/tags/aws)
 - [Datadog - Application Monitoring](https://notes.yxy.ninja/tags/Datadog)
@@ -148,9 +164,11 @@ I am planning to work on my notes daily for the next **10 years**, building a se
 - [Docker (Under heavy revision)](https://notes.yxy.ninja/tags/docker)
 - [Object Oriented Programming](https://notes.yxy.ninja/tags/OOP)
 
+<a id="networking"></a>
+<details>
+<summary><strong>🕸️ Networking</strong></summary>
 
-### 🕸️ Networking
 - [Networking Basis (Under heavy revision)](https://notes.yxy.ninja/tags/networking)
 
-
+</details>
 

--- a/content/index.md
+++ b/content/index.md
@@ -19,123 +19,1387 @@ description: Your go-to second brain for learning and sharing computer science c
 
 🙏🏻 Please feel free to [provide feedback](https://github.com/xy-241/CS-Notes/issues) regarding the accuracy of the notes, etc.
 
-## 🎓 NUS Computer Science
----
-- [[CS2106 Introduction to Operating Systems]]
-- [[CS1231S Discrete Structures]]
-- [[CS2100 Computer Organisation]]
-- [[CS2030S Programming Methodology II]]
+## Notes Navigator 🧭
 
-## 🏭 System Design
----
-- [Basis](https://notes.yxy.ninja/System-Design/)
-- [Proxy](https://notes.yxy.ninja/System-Design/Proxy/)
-- [Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/)
-- [Database](https://notes.yxy.ninja/System-Design/Database/)
-- [Cache](https://notes.yxy.ninja/System-Design/Cache/)
-- [Compute](https://notes.yxy.ninja/System-Design/Compute/)
-- [Monitoring](https://notes.yxy.ninja/System-Design/Monitoring/)
-- [Architecture](https://notes.yxy.ninja/System-Design/Architectures/)
+Use the quick index below to jump straight to the topics you care about. Expand any domain to browse the underlying tags and linked notes.
 
+| Domain | Focus |
+| --- | --- |
+| [Architecture, Cloud & Operations](#architecture-cloud-operations) | System design blueprints, observability, and cloud platform building blocks |
+| [Networking & Distributed Systems](#networking-distributed-systems) | Protocols, distributed primitives, and edge connectivity |
+| [Operating Systems, Hardware & HPC](#operating-systems-hardware-hpc) | Kernel internals, memory models, and digital logic |
+| [Programming Languages & Paradigms](#programming-languages-paradigms) | Language idioms, paradigms, and ecosystem insights |
+| [Software Engineering & Tooling](#software-engineering-tooling) | Engineering workflows, CLI mastery, and productivity tooling |
+| [Algorithms, Data Structures & Math](#algorithms-data-structures-math) | Problem-solving playbooks, math fundamentals, and contest prep |
+| [Data Management](#data-management) | Relational theory, storage engines, and SQL patterns |
+| [Security & Identity](#security-identity) | Security architecture, authentication, and enterprise trust |
+| [Career, Finance & Academia](#career-finance-academia) | Professional growth, financial literacy, and academic references |
+| [AI & Emerging Tech](#ai-emerging-tech) | High-performance AI workloads and modern ML infrastructure |
+| [Visual Library](#visual-library) | Hand-crafted Excalidraw diagrams and visual aids |
 
-## 💻 Operating System
----
-- [Intro](https://notes.yxy.ninja/OS/)
-</br>
+<a id="architecture-cloud-operations"></a>
+<details>
+<summary><strong>Architecture, Cloud & Operations</strong></summary>
 
-- [CPU](https://notes.yxy.ninja/OS/CPU/)
-- [File System](https://notes.yxy.ninja/OS/File-System/)
-- [IO](https://notes.yxy.ninja/OS/IO/)
-- [Memory](https://notes.yxy.ninja/OS/Memory/)
-</br>
+<details>
+<summary><code>system_design</code> · 24 notes</summary>
 
-- [Process (进程)](https://notes.yxy.ninja/OS/Process/)
-- [Thread (线程)](https://notes.yxy.ninja/OS/Thread/)
-- [Synchronization (同步)](https://notes.yxy.ninja/OS/Synchronization/)
-</br>
+- [Application Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Application-Load-Balancer)
+- [Cache Eviction](https://notes.yxy.ninja/System-Design/Cache/Cache-Eviction)
+- [Cache Server](https://notes.yxy.ninja/System-Design/Cache/Cache-Server)
+- [CDN](https://notes.yxy.ninja/System-Design/Cache/CDN)
+- [Compute Server](https://notes.yxy.ninja/System-Design/Compute/Compute-Server)
+- [Database Partitioning](https://notes.yxy.ninja/Database/Database-Partitioning)
+- [Database Replication (数据库复制)](https://notes.yxy.ninja/System-Design/Database/Database-Replication-(数据库复制))
+- [Database Scaling](https://notes.yxy.ninja/System-Design/Database/Database-Scaling)
+- [Deployment Strategies](https://notes.yxy.ninja/System-Design/Deployment-Strategies)
+- [Event-Driven Architecture](https://notes.yxy.ninja/System-Design/Architectures/Event-Driven-Architecture)
+- [Forward Proxy (正向代理)](https://notes.yxy.ninja/System-Design/Proxy/Forward-Proxy-(正向代理))
+- [Hub and Spoke Architecture](https://notes.yxy.ninja/System-Design/Architectures/Hub-and-Spoke-Architecture)
+- [Latency Number](https://notes.yxy.ninja/System-Design/Latency-Number)
+- [Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Load-Balancer)
+- [Message Queue (消息队列)](https://notes.yxy.ninja/System-Design/Compute/Message-Queue-(消息队列))
+- [Micro-servercies Architecture](https://notes.yxy.ninja/System-Design/Architectures/Micro-servercies-Architecture)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Multi Data Center Setup](https://notes.yxy.ninja/System-Design/Compute/Multi-Data-Center-Setup)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Network Load Balancer](https://notes.yxy.ninja/System-Design/Load-Balancers/Network-Load-Balancer)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+- [REST API](https://notes.yxy.ninja/Networking-MISC/REST-API)
+- [Reverse Proxy (反向代理)](https://notes.yxy.ninja/System-Design/Proxy/Reverse-Proxy-(反向代理))
+- [System Design](https://notes.yxy.ninja/System-Design/System-Design)
 
-- [Interrupt (中断)](https://notes.yxy.ninja/OS/Interrupt/)
-- [System-Calls (系统调用)](https://notes.yxy.ninja/OS/System-Call/)
-</br>
+</details>
 
-- [UNIX vs Linux](https://notes.yxy.ninja/OS/UNIX-vs-Linux/)
-- [MISC](https://notes.yxy.ninja/OS/Terminologies/)
+<details>
+<summary><code>devops</code> · 10 notes</summary>
 
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Memory Monitoring](https://notes.yxy.ninja/Devops/Memory-Monitoring)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Observability](https://notes.yxy.ninja/Devops/Observability)
+- [Prometheus](https://notes.yxy.ninja/Devops/Prometheus)
+- [Prometheus On Macos](https://notes.yxy.ninja/Devops/Prometheus-On-Macos)
+- [PromQL](https://notes.yxy.ninja/Devops/PromQL)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+- [Terraform Cheatsheet](https://notes.yxy.ninja/Tools/IaC/Terraform-Cheatsheet)
+- [Terraform Project Structure](https://notes.yxy.ninja/Tools/IaC/Terraform-Project-Structure)
 
-## 🖥️ Computer Organisation 
----
-- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/)
-- [Processor](https://notes.yxy.ninja/Computer-Organisation/Processor/)
-</br>
+</details>
 
-- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/)
-- [MIPS](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/)
-- [RISCV](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/)
-</br>
+<details>
+<summary><code>aws</code> · 22 notes</summary>
 
-- [Pipeline](https://notes.yxy.ninja/Computer-Organisation/Pipeline/)
-- [Pipeline Branching](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/)
-- [Pipeline Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/)
-</br>
+- [ASG](https://notes.yxy.ninja/AWS/Compute/ASG)
+- [AWS ACL](https://notes.yxy.ninja/AWS/Security/AWS-ACL)
+- [AWS ALB](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/AWS-ALB)
+- [AWS Backup](https://notes.yxy.ninja/AWS/Disaster-Recovery/AWS-Backup)
+- [AWS Database](https://notes.yxy.ninja/AWS/Database/AWS-Database)
+- [AWS EventBridge](https://notes.yxy.ninja/AWS/AWS-EventBridge)
+- [AWS Explorer](https://notes.yxy.ninja/AWS/AWS-Explorer)
+- [AWS Lambda](https://notes.yxy.ninja/AWS/Compute/AWS-Lambda)
+- [AWS NLB](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/AWS-NLB)
+- [AWS Nuke](https://notes.yxy.ninja/AWS/AWS-Nuke)
+- [AWS Parameter Store](https://notes.yxy.ninja/AWS/Storage/AWS-Parameter-Store)
+- [AWS Subnet](https://notes.yxy.ninja/AWS/Networking/AWS-Subnet)
+- [AWS Transit Gateway](https://notes.yxy.ninja/AWS/Networking/AWS-Transit-Gateway)
+- [AWS VPC Endpoint](https://notes.yxy.ninja/AWS/Networking/AWS-VPC-Endpoint)
+- [EC2](https://notes.yxy.ninja/AWS/Compute/EC2)
+- [ECS](https://notes.yxy.ninja/AWS/Compute/ECS/ECS)
+- [ECS Exec](https://notes.yxy.ninja/AWS/Compute/ECS/ECS-Exec)
+- [EFS](https://notes.yxy.ninja/AWS/Storage/EFS)
+- [KMS](https://notes.yxy.ninja/AWS/Security/KMS)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+- [Security Group](https://notes.yxy.ninja/AWS/Security/Security-Group)
+- [Target Group](https://notes.yxy.ninja/AWS/Compute/Load-Balancer/Target-Group)
 
-- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/)
-- [Combination Circuit](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/)
-- [Sequential Circuit](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/)
-- [Circuit Design](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/)
-</br>
+</details>
 
+<details>
+<summary><code>cloudflare</code> · 12 notes</summary>
 
+- [CDN](https://notes.yxy.ninja/System-Design/Cache/CDN)
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Cloudflare Access](https://notes.yxy.ninja/Security/Authentication/Cloudflare-Access)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [DNS Record](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Record)
+- [DNS Server](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Server)
+- [Email Routing](https://notes.yxy.ninja/Networking-Concepts/Email-Routing)
+- [Hostname](https://notes.yxy.ninja/Networking-Protocol/DNS/Hostname)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SEO](https://notes.yxy.ninja/Networking-Concepts/SEO)
 
-## 🧠 Data Structure & Algorithm
----
-- [Problem Solving Tricks](https://notes.yxy.ninja/tags/problem_solving)
-- [[Data Structure Content Page]]
-- [[Algorithm Content Page]]
+</details>
 
+<details>
+<summary><code>docker</code> · 12 notes</summary>
 
+- [Docker](https://notes.yxy.ninja/Tools/Docker/Docker)
+- [Docker Build](https://notes.yxy.ninja/Tools/Docker/Docker-Build)
+- [Docker Compose](https://notes.yxy.ninja/Tools/Docker/Docker-Compose)
+- [Docker Container](https://notes.yxy.ninja/Tools/Docker/3-Components/Docker-Container)
+- [Docker EXEC Command Flags](https://notes.yxy.ninja/Tools/Docker/Command-Cheatsheets/Docker-EXEC-Command-Flags)
+- [Docker Filesytem](https://notes.yxy.ninja/Tools/Docker/Docker-Filesytem)
+- [Docker Network](https://notes.yxy.ninja/Tools/Docker/Docker-Network)
+- [Docker RUN Command Flags](https://notes.yxy.ninja/Tools/Docker/Command-Cheatsheets/Docker-RUN-Command-Flags)
+- [Docker Volume](https://notes.yxy.ninja/Tools/Docker/Docker-Volume)
+- [Dockerfile](https://notes.yxy.ninja/Tools/Docker/3-Components/Dockerfile)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [Virtualisation](https://notes.yxy.ninja/Virtualisation)
 
-## 👩‍💻 Competitive Programming
----
-- [Code Template](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
-- [Data Structure](https://notes.yxy.ninja/cp/data_structure/)
-- [Prefix Sum](https://notes.yxy.ninja/cp/prefix_sum/)
-- [Dynamic Programming](https://notes.yxy.ninja/cp/dynamic_programming/)
-- [Greedy](https://notes.yxy.ninja/cp/greedy/)
-- [Number Theory](https://notes.yxy.ninja/cp/number_theory/)
-- [Combinatorics](https://notes.yxy.ninja/cp/combinatorics/)
+</details>
 
+<details>
+<summary><code>Datadog</code> · 4 notes</summary>
 
-## ➕ Math
----
-- [Number Theory Basis](https://notes.yxy.ninja/tags/number_theory)
-- [Divisibility & Primes](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/)
-</br>
+- [Datadog](https://notes.yxy.ninja/Tools/Datadog/Datadog)
+- [Datadog APM](https://notes.yxy.ninja/Tools/Datadog/Datadog-APM)
+- [Datadog Lambda Monitoring](https://notes.yxy.ninja/Tools/Datadog/Datadog-Lambda-Monitoring)
+- [Datadog RUM](https://notes.yxy.ninja/Tools/Datadog/Datadog-RUM)
 
-- [Discrete Math](https://notes.yxy.ninja/tags/discrete_math)
-- [Boolean Algebra](https://notes.yxy.ninja/tags/boolean_algebra)
+</details>
 
+<details>
+<summary><code>terraform</code> · 4 notes</summary>
 
-## 🔤 Programming Language
----
-- [C](https://notes.yxy.ninja/tags/c)
-- [Python](https://notes.yxy.ninja/tags/python)
-- [Rust](https://notes.yxy.ninja/tags/rust)
-- [Java](https://notes.yxy.ninja/tags/java)
-- [Javascript](https://notes.yxy.ninja/tags/js)
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Terraform Cheatsheet](https://notes.yxy.ninja/Tools/IaC/Terraform-Cheatsheet)
+- [Terraform Project Structure](https://notes.yxy.ninja/Tools/IaC/Terraform-Project-Structure)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
 
+</details>
 
-## 🛠️ Software Engineering 
----
-- [Software Engineering Theories](https://notes.yxy.ninja/tags/software_engineering)
-- [Amazon Web Services](https://notes.yxy.ninja/tags/aws)
-- [Datadog - Application Monitoring](https://notes.yxy.ninja/tags/Datadog)
-- [Security](https://notes.yxy.ninja/tags/security)
-- [Docker (Under heavy revision)](https://notes.yxy.ninja/tags/docker)
-- [Object Oriented Programming](https://notes.yxy.ninja/tags/OOP)
+<details>
+<summary><code>gcp</code> · 1 note</summary>
 
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
 
+</details>
 
-## 🕸️ Networking
----
-- [Networking Basis (Under heavy revision)](https://notes.yxy.ninja/tags/networking)
+<details>
+<summary><code>fly_io</code> · 2 notes</summary>
 
+- [Fly.io](https://notes.yxy.ninja/Tools/Fly.io)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+
+</details>
+
+<details>
+<summary><code>ngrok</code> · 1 note</summary>
+
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+
+</details>
+
+<details>
+<summary><code>over</code> · 2 notes</summary>
+
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+
+</details>
+
+</details>
+
+<a id="networking-distributed-systems"></a>
+<details>
+<summary><strong>Networking & Distributed Systems</strong></summary>
+
+<details>
+<summary><code>networking</code> · 95 notes</summary>
+
+- [Access Control List](https://notes.yxy.ninja/Security/Access-Control-List)
+- [Access Network](https://notes.yxy.ninja/Networking-MISC/Access-Network)
+- [Address Resolution Protocol](https://notes.yxy.ninja/Networking-Protocol/Address-Resolution-Protocol)
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [AS](https://notes.yxy.ninja/Networking-Protocol/AS)
+- [AWS VPC Endpoint](https://notes.yxy.ninja/AWS/Networking/AWS-VPC-Endpoint)
+- [Bandwidth](https://notes.yxy.ninja/Networking-MISC/Bandwidth)
+- [Border Gateway Protocol](https://notes.yxy.ninja/Networking-Protocol/Border-Gateway-Protocol)
+- [Communication Links](https://notes.yxy.ninja/Networking-Devices/Communication-Links)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [CSMA](https://notes.yxy.ninja/Networking-Protocol/CSMA)
+- [DHCP](https://notes.yxy.ninja/Networking-Protocol/DHCP)
+- [Digital Signature](https://notes.yxy.ninja/Security/Cryptography/Digital-Signature)
+- [Digital Subscriber Line (DSL)](https://notes.yxy.ninja/Networking-Devices/Digital-Subscriber-Line-(DSL))
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [DNS Record](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Record)
+- [DNS Server](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS-Server)
+- [Docker](https://notes.yxy.ninja/Tools/Docker/Docker)
+- [Docker Network](https://notes.yxy.ninja/Tools/Docker/Docker-Network)
+- [Dynamic Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Dynamic-Port-Forwarding)
+- [Dynamic Routing Protocol](https://notes.yxy.ninja/Networking-Concepts/Dynamic-Routing-Protocol)
+- [Email Routing](https://notes.yxy.ninja/Networking-Concepts/Email-Routing)
+- [Email Security](https://notes.yxy.ninja/Security/Email-Security)
+- [End-to-End Service Access Troubleshooting](https://notes.yxy.ninja/Tools/End-to-End-Service-Access-Troubleshooting)
+- [Ethernet](https://notes.yxy.ninja/Networking-Protocol/Ethernet)
+- [Exponential Backoff](https://notes.yxy.ninja/Networking-MISC/Exponential-Backoff)
+- [File Sharing](https://notes.yxy.ninja/Networking-Concepts/File-Sharing)
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Head-of-Line Blocking (队头堵塞)](https://notes.yxy.ninja/Networking-Protocol/HTTP/Head-of-Line-Blocking-(队头堵塞))
+- [Host](https://notes.yxy.ninja/Networking-MISC/Host)
+- [Hostname](https://notes.yxy.ninja/Networking-Protocol/DNS/Hostname)
+- [Hot Standby Router Protocol](https://notes.yxy.ninja/Networking-Protocol/Hot-Standby-Router-Protocol)
+- [HTTP](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP)
+- [HTTP 1.0](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-1.0)
+- [HTTP 1.1](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-1.1)
+- [HTTP 2.0](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-2.0)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+- [HTTP Request](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Request)
+- [HTTP Request Methods](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Request-Methods)
+- [HTTP Response](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Response)
+- [HTTP Status Code](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Status-Code)
+- [ICMP](https://notes.yxy.ninja/Networking-Concepts/ICMP)
+- [Internet](https://notes.yxy.ninja/Networking-MISC/Internet)
+- [Internet Protocol (IP)](https://notes.yxy.ninja/Networking-Protocol/Internet-Protocol-(IP))
+- [IP Address](https://notes.yxy.ninja/Networking-Protocol/DNS/IP-Address)
+- [ISP](https://notes.yxy.ninja/Networking-MISC/ISP)
+- [Kubernetes Networking](https://notes.yxy.ninja/Networking-MISC/Kubernetes-Networking)
+- [Link-layer switches](https://notes.yxy.ninja/Networking-Devices/Link-layer-switches)
+- [Local Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Local-Port-Forwarding)
+- [MAC Address](https://notes.yxy.ninja/Networking-Concepts/MAC-Address)
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [NAT](https://notes.yxy.ninja/Networking-Concepts/NAT)
+- [Netfilter](https://notes.yxy.ninja/Networking-MISC/Netfilter)
+- [Network Bridge](https://notes.yxy.ninja/Networking-Devices/Network-Bridge)
+- [Network Firewall](https://notes.yxy.ninja/Networking-MISC/Network-Firewall)
+- [Network Interface](https://notes.yxy.ninja/Networking-Devices/Network-Interface)
+- [Network Object](https://notes.yxy.ninja/Networking-MISC/Network-Object)
+- [Network Operations](https://notes.yxy.ninja/Networking-MISC/Network-Operations)
+- [Network Packet](https://notes.yxy.ninja/Networking-MISC/Network-Packet)
+- [Network Port](https://notes.yxy.ninja/Networking-MISC/Network-Port)
+- [Network Protocol](https://notes.yxy.ninja/Networking-Protocol/Network-Protocol)
+- [Network Relay](https://notes.yxy.ninja/Networking-Concepts/Network-Relay)
+- [Network Router](https://notes.yxy.ninja/Networking-Devices/Network-Router)
+- [Network Switch](https://notes.yxy.ninja/Networking-Devices/Network-Switch)
+- [OpenWRT](https://notes.yxy.ninja/Networking-MISC/OpenWRT)
+- [OSI Model](https://notes.yxy.ninja/Networking-Concepts/OSI-Model)
+- [OSPF](https://notes.yxy.ninja/Networking-Concepts/OSPF)
+- [Port Channel](https://notes.yxy.ninja/Networking-Concepts/Port-Channel)
+- [QUIC](https://notes.yxy.ninja/Networking-Protocol/HTTP/QUIC)
+- [Real-time Web Communication](https://notes.yxy.ninja/Networking-Concepts/Real-time-Web-Communication)
+- [Remote Port Forwarding](https://notes.yxy.ninja/Networking-Concepts/Remote-Port-Forwarding)
+- [REST API](https://notes.yxy.ninja/Networking-MISC/REST-API)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SEO](https://notes.yxy.ninja/Networking-Concepts/SEO)
+- [Server Mirroring](https://notes.yxy.ninja/Networking-Concepts/Server-Mirroring)
+- [Shadowsocks](https://notes.yxy.ninja/Networking-MISC/Shadowsocks)
+- [SOCKS](https://notes.yxy.ninja/Networking-Protocol/SOCKS)
+- [Spanning Tree Protocol](https://notes.yxy.ninja/Networking-Protocol/Spanning-Tree-Protocol)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Subnet](https://notes.yxy.ninja/Networking-Concepts/Subnet)
+- [TCP](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP)
+- [TCP Connection](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP-Connection)
+- [TCP Handshake](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP-Handshake)
+- [TCP Tunneling](https://notes.yxy.ninja/Networking-Concepts/TCP-Tunneling)
+- [Tethering](https://notes.yxy.ninja/Networking-MISC/Tethering)
+- [TLS](https://notes.yxy.ninja/Networking-Protocol/TLS/TLS)
+- [TLS 1.2](https://notes.yxy.ninja/Networking-Protocol/TLS/TLS-1.2)
+- [Transmission rate](https://notes.yxy.ninja/Networking-MISC/Transmission-rate)
+- [TTL](https://notes.yxy.ninja/Networking-MISC/TTL)
+- [UDP](https://notes.yxy.ninja/Networking-Protocol/UDP)
+- [URL](https://notes.yxy.ninja/Networking-MISC/URL)
+- [VLAN](https://notes.yxy.ninja/Networking-Concepts/VLAN)
+- [VPN](https://notes.yxy.ninja/Networking-Protocol/VPN)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
+
+</details>
+
+<details>
+<summary><code>distributed_computing</code> · 5 notes</summary>
+
+- [Distributed Consensus](https://notes.yxy.ninja/Distributed-Computing/Consensus/Distributed-Consensus)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Raft Consensus Algorithm](https://notes.yxy.ninja/Distributed-Computing/Consensus/Raft-Consensus-Algorithm)
+- [Replicated State Machine](https://notes.yxy.ninja/Distributed-Computing/Consensus/Replicated-State-Machine)
+- [Span](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Span)
+
+</details>
+
+<details>
+<summary><code>curl</code> · 2 notes</summary>
+
+- [curl](https://notes.yxy.ninja/Bash/Networking/curl)
+- [HTTP Headers](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP-Headers)
+
+</details>
+
+</details>
+
+<a id="operating-systems-hardware-hpc"></a>
+<details>
+<summary><strong>Operating Systems, Hardware & HPC</strong></summary>
+
+<details>
+<summary><code>OS</code> · 109 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Async IO](https://notes.yxy.ninja/OS/IO/Async-IO)
+- [Banker's Algorithm](https://notes.yxy.ninja/Algorithm/Banker's-Algorithm)
+- [Barrier (屏障)](https://notes.yxy.ninja/OS/Synchronization/Barrier-(屏障))
+- [Buffer](https://notes.yxy.ninja/OS/IO/Buffer)
+- [Busy Waiting](https://notes.yxy.ninja/OS/Synchronization/Busy-Waiting)
+- [Cache Locality](https://notes.yxy.ninja/OS/CPU/Cache-Locality)
+- [Computer Booting](https://notes.yxy.ninja/OS/Computer-Booting)
+- [Concurrency (并发)](https://notes.yxy.ninja/OS/Synchronization/Concurrency-(并发))
+- [Condition Variable (条件变量)](https://notes.yxy.ninja/OS/Synchronization/Condition-Variable-(条件变量))
+- [Containerisation](https://notes.yxy.ninja/OS/Containerisation)
+- [Context Switch](https://notes.yxy.ninja/OS/Process/Context-Switch)
+- [CPU Cache](https://notes.yxy.ninja/OS/CPU/CPU-Cache)
+- [CPU Scheduling Techniques](https://notes.yxy.ninja/OS/CPU/CPU-Scheduling-Techniques)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [CS2106 Introduction to Operating Systems](https://notes.yxy.ninja/NUS/CS2106-Introduction-to-Operating-Systems)
+- [CUDA](https://notes.yxy.ninja/Hpc/CUDA)
+- [CUDA Synchronization](https://notes.yxy.ninja/Hpc/CUDA-Synchronization)
+- [Database Comparison](https://notes.yxy.ninja/Database/Database-Comparison)
+- [Deadlock (死锁)](https://notes.yxy.ninja/OS/Synchronization/Deadlock-(死锁))
+- [Device Controller](https://notes.yxy.ninja/OS/IO/Device-Controller)
+- [Direct Memory Access (DMA)](https://notes.yxy.ninja/OS/IO/Direct-Memory-Access-(DMA))
+- [Docker Filesytem](https://notes.yxy.ninja/Tools/Docker/Docker-Filesytem)
+- [DuckDB](https://notes.yxy.ninja/Database/DuckDB)
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [File](https://notes.yxy.ninja/OS/File-System/File)
+- [File Compression](https://notes.yxy.ninja/OS/File-System/File-Compression)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [File System Link](https://notes.yxy.ninja/OS/File-System/File-System-Link)
+- [Filter File](https://notes.yxy.ninja/OS/File-System/Filter-File)
+- [Flash Memory](https://notes.yxy.ninja/OS/Memory/Flash-Memory)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [GIL](https://notes.yxy.ninja/Python/GIL)
+- [Global Interpreter Lock](https://notes.yxy.ninja/OS/Synchronization/Global-Interpreter-Lock)
+- [Goroutine](https://notes.yxy.ninja/OS/Thread/Goroutine)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+- [Hybrid Thread](https://notes.yxy.ninja/OS/Thread/Hybrid-Thread)
+- [Init System](https://notes.yxy.ninja/OS/Tools/Init-System)
+- [Inode](https://notes.yxy.ninja/OS/File-System/Inode)
+- [Inter-Process Communication](https://notes.yxy.ninja/OS/Process/Inter-Process-Communication)
+- [Interrupt Handler](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Handler)
+- [Interrupt Vector Table](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Vector-Table)
+- [Interrupts (中断)](https://notes.yxy.ninja/OS/Interrupt/Interrupts-(中断))
+- [IO Bus](https://notes.yxy.ninja/OS/IO/IO-Bus)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Kernel](https://notes.yxy.ninja/OS/Kernel)
+- [Kernel Space](https://notes.yxy.ninja/OS/Kernel-Space)
+- [Kernel Thread](https://notes.yxy.ninja/OS/Thread/Kernel-Thread)
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Library Call](https://notes.yxy.ninja/OS/System-Call/Library-Call)
+- [Linux Address Space](https://notes.yxy.ninja/OS/Process/Linux-Address-Space)
+- [Linux Kernel](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Linux-Kernel)
+- [Main Memory](https://notes.yxy.ninja/OS/Memory/Main-Memory)
+- [Memory Fragmentation](https://notes.yxy.ninja/OS/Memory/Memory-Fragmentation)
+- [Memory Page](https://notes.yxy.ninja/OS/Memory/Memory-Page)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [MMU](https://notes.yxy.ninja/OS/CPU/MMU)
+- [Multi-core Chip](https://notes.yxy.ninja/OS/CPU/Multi-core-Chip)
+- [Multi-processing](https://notes.yxy.ninja/OS/CPU/Multi-processing)
+- [Multi-Programming](https://notes.yxy.ninja/OS/CPU/Multi-Programming)
+- [Multi-threading](https://notes.yxy.ninja/OS/CPU/Multi-threading)
+- [Multipart Upload](https://notes.yxy.ninja/Distributed-Computing/Multipart-Upload)
+- [Mutex (互斥体)](https://notes.yxy.ninja/OS/Synchronization/Mutex-(互斥体))
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [OS](https://notes.yxy.ninja/OS/OS)
+- [OS System Program](https://notes.yxy.ninja/OS/OS-System-Program)
+- [Page Fault](https://notes.yxy.ninja/OS/Memory/Page-Fault)
+- [Page Table](https://notes.yxy.ninja/OS/Memory/Page-Table)
+- [Pipe (管道)](https://notes.yxy.ninja/OS/File-System/Pipe-(管道))
+- [POSIX](https://notes.yxy.ninja/OS/UNIX-vs-Linux/POSIX)
+- [Privilege Level](https://notes.yxy.ninja/OS/CPU/Privilege-Level)
+- [Process (进程)](https://notes.yxy.ninja/OS/Process/Process-(进程))
+- [Process Control Block (PCB)](https://notes.yxy.ninja/OS/Process/Process-Control-Block-(PCB))
+- [Process File](https://notes.yxy.ninja/OS/Process/Process-File)
+- [Process Hierarchy](https://notes.yxy.ninja/OS/Process/Process-Hierarchy)
+- [Process Operations](https://notes.yxy.ninja/OS/Process/Process-Operations)
+- [Process Scheduling](https://notes.yxy.ninja/OS/Process/Process-Scheduling)
+- [Producer Consumer Problem](https://notes.yxy.ninja/OS/Thread/Producer-Consumer-Problem)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Race Condition (竞态条件)](https://notes.yxy.ninja/OS/Synchronization/Race-Condition-(竞态条件))
+- [Register](https://notes.yxy.ninja/Computer-Organisation/Processor/Register)
+- [RISCV CLINT](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-CLINT)
+- [Rust Ownership](https://notes.yxy.ninja/Rust/Rust-Ownership)
+- [Segmentation Fault](https://notes.yxy.ninja/OS/Memory/Segmentation-Fault)
+- [Semaphore (信号量)](https://notes.yxy.ninja/OS/Synchronization/Semaphore-(信号量))
+- [Serial Communication](https://notes.yxy.ninja/OS/IO/Serial-Communication)
+- [Socket](https://notes.yxy.ninja/OS/Process/Socket)
+- [Stack](https://notes.yxy.ninja/Data-Structure/Stack)
+- [Swap Space](https://notes.yxy.ninja/OS/Memory/Swap-Space)
+- [Synchronisation (同步)](https://notes.yxy.ninja/OS/Synchronization/Synchronisation-(同步))
+- [System Call (系统调用)](https://notes.yxy.ninja/OS/System-Call/System-Call-(系统调用))
+- [Systemd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Systemd)
+- [Thread](https://notes.yxy.ninja/OS/Thread/Thread)
+- [Thread Pool](https://notes.yxy.ninja/OS/Thread/Thread-Pool)
+- [Time Slice](https://notes.yxy.ninja/OS/Process/Time-Slice)
+- [Timer Chip](https://notes.yxy.ninja/OS/Interrupt/Timer-Chip)
+- [TLB](https://notes.yxy.ninja/OS/CPU/TLB)
+- [Trap Interrupt (陷入)](https://notes.yxy.ninja/OS/Interrupt/Trap-Interrupt-(陷入))
+- [Unix](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Unix)
+- [User](https://notes.yxy.ninja/OS/Terminologies/User)
+- [User Space](https://notes.yxy.ninja/OS/User-Space)
+- [User Thread](https://notes.yxy.ninja/OS/Thread/User-Thread)
+- [VFS](https://notes.yxy.ninja/OS/File-System/VFS)
+- [Virtual Memory](https://notes.yxy.ninja/OS/Memory/Virtual-Memory)
+- [Virtualisation](https://notes.yxy.ninja/Virtualisation)
+
+</details>
+
+<details>
+<summary><code>os</code> · 4 notes</summary>
+
+- [CPU Load](https://notes.yxy.ninja/OS/CPU/CPU-Load)
+- [CUDA Memory](https://notes.yxy.ninja/Hpc/CUDA-Memory)
+- [Kernel Panic](https://notes.yxy.ninja/OS/Kernel-Panic)
+- [Memory Monitoring](https://notes.yxy.ninja/Devops/Memory-Monitoring)
+
+</details>
+
+<details>
+<summary><code>linux</code> · 13 notes</summary>
+
+- [Computer Booting](https://notes.yxy.ninja/OS/Computer-Booting)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Kernel](https://notes.yxy.ninja/OS/Kernel)
+- [Linux Kernel](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Linux-Kernel)
+- [Linux Namespace](https://notes.yxy.ninja/Bash/Linux-Namespace)
+- [POSIX](https://notes.yxy.ninja/OS/UNIX-vs-Linux/POSIX)
+- [Process (进程)](https://notes.yxy.ninja/OS/Process/Process-(进程))
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [User](https://notes.yxy.ninja/OS/Terminologies/User)
+
+</details>
+
+<details>
+<summary><code>macos</code> · 5 notes</summary>
+
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [FUSE](https://notes.yxy.ninja/OS/File-System/FUSE)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Secure Tunneling](https://notes.yxy.ninja/Networking-Concepts/Secure-Tunneling)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+
+</details>
+
+<details>
+<summary><code>computer_organisation</code> · 100 notes</summary>
+
+- [Adder](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Adder)
+- [ALU](https://notes.yxy.ninja/Computer-Organisation/Processor/ALU)
+- [AND](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/AND)
+- [Assembly language](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Assembly-language)
+- [Atomic Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Atomic-Instruction)
+- [Base 64 Encoding](https://notes.yxy.ninja/Computer-Organisation/Number-System/Base-64-Encoding)
+- [Bit Shifting](https://notes.yxy.ninja/Boolean-Algebra/Bit-Shifting)
+- [Bitmasking](https://notes.yxy.ninja/Boolean-Algebra/Bitmasking)
+- [Boolean Algebra](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Algebra)
+- [Boolean Function](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Function)
+- [Boolean Standard Form](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Standard-Form)
+- [Branch Prediction](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Branch-Prediction)
+- [Branch Prediction Strategies (Heuristics)](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Branch-Prediction-Strategies-(Heuristics))
+- [C Array](https://notes.yxy.ninja/C/C-Array)
+- [C Datatype](https://notes.yxy.ninja/C/C-Datatype)
+- [C Function](https://notes.yxy.ninja/C/C-Function)
+- [C String](https://notes.yxy.ninja/C/C-String)
+- [Cache Eviction](https://notes.yxy.ninja/System-Design/Cache/Cache-Eviction)
+- [Cache Locality](https://notes.yxy.ninja/OS/CPU/Cache-Locality)
+- [Cache Miss](https://notes.yxy.ninja/OS/CPU/Cache-Miss)
+- [Cache Strategy](https://notes.yxy.ninja/OS/CPU/Cache-Strategy)
+- [Character Encoding (字符编码）](https://notes.yxy.ninja/Computer-Organisation/Number-System/Character-Encoding-(字符编码）)
+- [Circuit Design](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Circuit-Design)
+- [CISC](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/CISC)
+- [Clock Oscillator](https://notes.yxy.ninja/Computer-Organisation/Processor/Clock-Oscillator)
+- [Combination Circuit](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Combination-Circuit)
+- [Complete Set of Logic](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Complete-Set-of-Logic)
+- [Computer Data Representation](https://notes.yxy.ninja/Computer-Organisation/Number-System/Computer-Data-Representation)
+- [Control Unit](https://notes.yxy.ninja/Computer-Organisation/Processor/Control-Unit)
+- [CPU](https://notes.yxy.ninja/Computer-Organisation/Processor/CPU)
+- [CPU Datapath](https://notes.yxy.ninja/Computer-Organisation/Processor/CPU-Datapath)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [Data Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Data-Latch)
+- [Decoder](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Decoder)
+- [Direct Mapped Cache](https://notes.yxy.ninja/OS/CPU/Direct-Mapped-Cache)
+- [Endianness](https://notes.yxy.ninja/Computer-Organisation/Number-System/Endianness)
+- [Flip-flop](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Flip-flop)
+- [Floating-Point Encoding (浮点数编码)](https://notes.yxy.ninja/Computer-Organisation/Number-System/Floating-Point-Encoding-(浮点数编码))
+- [FPGA](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/FPGA)
+- [Fully Associative Cache](https://notes.yxy.ninja/OS/CPU/Fully-Associative-Cache)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [GPU](https://notes.yxy.ninja/Computer-Organisation/Processor/GPU)
+- [Gray Code](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Gray-Code)
+- [Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction)
+- [Instruction Execution](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Execution)
+- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Set-Architecture-(ISA))
+- [Instruction Stages](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Instruction-Stages)
+- [Instruction-Level Parallelism](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Instruction-Level-Parallelism)
+- [Integer Encoding (数字编码)](https://notes.yxy.ninja/Computer-Organisation/Number-System/Integer-Encoding-(数字编码))
+- [ISA Addressing Mode](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Addressing-Mode)
+- [ISA Instruction Format](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Instruction-Format)
+- [ISA Storage Architecture](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/ISA-Storage-Architecture)
+- [Karnaugh Map](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Karnaugh-Map)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Latch)
+- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Logic-Gates)
+- [Macro Expansion](https://notes.yxy.ninja/C/Macro-Expansion)
+- [Main Memory](https://notes.yxy.ninja/OS/Memory/Main-Memory)
+- [Maxterm](https://notes.yxy.ninja/Boolean-Algebra/Maxterm)
+- [Memory Address](https://notes.yxy.ninja/OS/Memory/Memory-Address)
+- [Minterm](https://notes.yxy.ninja/Boolean-Algebra/Minterm)
+- [MIPS](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS)
+- [MIPS ALU](https://notes.yxy.ninja/Computer-Organisation/Processor/MIPS-ALU)
+- [MIPS Control Flow](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Control-Flow)
+- [MIPS Control Unit](https://notes.yxy.ninja/Computer-Organisation/Processor/MIPS-Control-Unit)
+- [MIPS Data Memory](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Data-Memory)
+- [MIPS I-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-I-Type-Instruction)
+- [MIPS Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Instruction)
+- [MIPS J-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-J-Type-Instruction)
+- [MIPS Memory Access](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Memory-Access)
+- [MIPS R-Type Instruction](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-R-Type-Instruction)
+- [MIPS Register](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/MIPS/MIPS-Register)
+- [Multiplexer](https://notes.yxy.ninja/Computer-Organisation/Combination-Circuit/Multiplexer)
+- [NOT](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOT)
+- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/Number-System)
+- [Operand Forwarding](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Operand-Forwarding)
+- [Operation](https://notes.yxy.ninja/Terminologies/Operation)
+- [OR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/OR)
+- [Out-of-Order Execution](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Out-of-Order-Execution)
+- [Pipeline Branching](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Pipeline-Branching)
+- [Pipeline Flush](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Branching/Pipeline-Flush)
+- [Pipeline Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Pipeline-Hazard)
+- [Pipeline Stall](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Pipeline-Stall)
+- [Pipelining](https://notes.yxy.ninja/Computer-Organisation/Pipeline/Pipelining)
+- [Pointer Arithmetic](https://notes.yxy.ninja/Programming/Pointer-Arithmetic)
+- [Programming Logic Array](https://notes.yxy.ninja/Computer-Organisation/Circuit-Design/Programming-Logic-Array)
+- [Read-After-Write(RAW) Hazard](https://notes.yxy.ninja/Computer-Organisation/Pipeline-Hazard/Read-After-Write(RAW)-Hazard)
+- [Register](https://notes.yxy.ninja/Computer-Organisation/Processor/Register)
+- [RISC](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISC)
+- [RISCV CLINT](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-CLINT)
+- [RISCV Instructure](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-Instructure)
+- [RISCV Kernel Deep Dive](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/RISCV/RISCV-Kernel-Deep-Dive)
+- [ROM](https://notes.yxy.ninja/OS/Memory/ROM)
+- [Sequential Circuit](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Sequential-Circuit)
+- [Sequential Circuit Analysis](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Sequential-Circuit-Analysis)
+- [Set Associative Cache](https://notes.yxy.ninja/OS/CPU/Set-Associative-Cache)
+- [Set Reset Latch](https://notes.yxy.ninja/Computer-Organisation/Sequential-Circuit/Set-Reset-Latch)
+- [Specialised Processor](https://notes.yxy.ninja/Computer-Organisation/Processor/Specialised-Processor)
+- [Transistors (晶体管)](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Transistors-(晶体管))
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+
+</details>
+
+<details>
+<summary><code>hpc</code> · 5 notes</summary>
+
+- [CUDA](https://notes.yxy.ninja/Hpc/CUDA)
+- [CUDA Memory](https://notes.yxy.ninja/Hpc/CUDA-Memory)
+- [CUDA Synchronization](https://notes.yxy.ninja/Hpc/CUDA-Synchronization)
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+- [Slurm](https://notes.yxy.ninja/Hpc/Slurm)
+
+</details>
+
+<details>
+<summary><code>arduino</code> · 4 notes</summary>
+
+- [Clock Oscillator](https://notes.yxy.ninja/Computer-Organisation/Processor/Clock-Oscillator)
+- [GPIO Pins](https://notes.yxy.ninja/Electronics/GPIO-Pins)
+- [ROM](https://notes.yxy.ninja/OS/Memory/ROM)
+- [Serial Communication](https://notes.yxy.ninja/OS/IO/Serial-Communication)
+
+</details>
+
+<details>
+<summary><code>opcode</code> · 1 note</summary>
+
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+
+</details>
+
+<details>
+<summary><code>boolean_algebra</code> · 11 notes</summary>
+
+- [AND](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/AND)
+- [Boolean Function](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Function)
+- [Boolean Standard Form](https://notes.yxy.ninja/Boolean-Algebra/Boolean-Standard-Form)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [Logic Gates](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/Logic-Gates)
+- [Maxterm](https://notes.yxy.ninja/Boolean-Algebra/Maxterm)
+- [Minterm](https://notes.yxy.ninja/Boolean-Algebra/Minterm)
+- [NOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOR)
+- [NOT](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/NOT)
+- [OR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/OR)
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+
+</details>
+
+</details>
+
+<a id="programming-languages-paradigms"></a>
+<details>
+<summary><strong>Programming Languages & Paradigms</strong></summary>
+
+<details>
+<summary><code>c</code> · 17 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [C](https://notes.yxy.ninja/C/C)
+- [C Array](https://notes.yxy.ninja/C/C-Array)
+- [C Datatype](https://notes.yxy.ninja/C/C-Datatype)
+- [C Function](https://notes.yxy.ninja/C/C-Function)
+- [C Keywords](https://notes.yxy.ninja/C/C-Keywords)
+- [C Program Compilation](https://notes.yxy.ninja/C/C-Program-Compilation)
+- [C String](https://notes.yxy.ninja/C/C-String)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Interrupt Handler](https://notes.yxy.ninja/OS/Interrupt/Interrupt-Handler)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Macro Expansion](https://notes.yxy.ninja/C/Macro-Expansion)
+- [Number System](https://notes.yxy.ninja/Computer-Organisation/Number-System/Number-System)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Pointer Arithmetic](https://notes.yxy.ninja/Programming/Pointer-Arithmetic)
+- [Semaphore (信号量)](https://notes.yxy.ninja/OS/Synchronization/Semaphore-(信号量))
+
+</details>
+
+<details>
+<summary><code>cpp</code> · 7 notes</summary>
+
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [CPP Notes](https://notes.yxy.ninja/C/CPP-Notes)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+
+</details>
+
+<details>
+<summary><code>java</code> · 41 notes</summary>
+
+- [Access Modifier](https://notes.yxy.ninja/Java/Access-Modifier)
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Boxing](https://notes.yxy.ninja/Java/Wrapper-Class/Boxing)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [CS2030S Programming Methodology II](https://notes.yxy.ninja/NUS/CS2030S-Programming-Methodology-II)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Dijkstra's Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Dijkstra's-Algorithm)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Dynamic Binding](https://notes.yxy.ninja/OOP/Dynamic-Binding)
+- [Exception](https://notes.yxy.ninja/Programming/Exception)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [Hash Map](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Map)
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [Java](https://notes.yxy.ninja/Java/Java)
+- [Java Comparison](https://notes.yxy.ninja/Java/Java-Comparison)
+- [Java Constructor](https://notes.yxy.ninja/Java/Java-Constructor)
+- [Java Keywords](https://notes.yxy.ninja/Java/Java-Keywords)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Java Optional](https://notes.yxy.ninja/Java/Java-Optional)
+- [Java Sorting](https://notes.yxy.ninja/Java/Java-Sorting)
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+- [Java Standard Library](https://notes.yxy.ninja/Java/Java-Standard-Library)
+- [Lazy Evaluation](https://notes.yxy.ninja/Functional/Lazy-Evaluation)
+- [Linked List](https://notes.yxy.ninja/Data-Structure/Linked-List)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [Method Overloading](https://notes.yxy.ninja/OOP/Method-Overloading)
+- [Method Overriding](https://notes.yxy.ninja/OOP/Method-Overriding)
+- [OOP](https://notes.yxy.ninja/OOP/OOP)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+- [Type Inference (类型推断)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Type-Inference-(类型推断))
+- [Variance](https://notes.yxy.ninja/OOP/Variance)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+- [Wrapper Class](https://notes.yxy.ninja/Java/Wrapper-Class/Wrapper-Class)
+
+</details>
+
+<details>
+<summary><code>python</code> · 20 notes</summary>
+
+- [AWS Lambda](https://notes.yxy.ninja/AWS/Compute/AWS-Lambda)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [GIL](https://notes.yxy.ninja/Python/GIL)
+- [Global Interpreter Lock](https://notes.yxy.ninja/OS/Synchronization/Global-Interpreter-Lock)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [HTTP](https://notes.yxy.ninja/Networking-Protocol/HTTP/HTTP)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Python Notes](https://notes.yxy.ninja/Programming/Python-Notes)
+- [Python Snippets for Markdown Processing](https://notes.yxy.ninja/Python-Snippets-for-Markdown-Processing)
+- [Python Toolset](https://notes.yxy.ninja/Tools/Python-Toolset)
+- [Pythonic Codes](https://notes.yxy.ninja/Programming/Pythonic-Codes)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+- [Union Find](https://notes.yxy.ninja/Data-Structure/Union-Find)
+
+</details>
+
+<details>
+<summary><code>rust</code> · 18 notes</summary>
+
+- [Address Space](https://notes.yxy.ninja/OS/Process/Address-Space)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Expression](https://notes.yxy.ninja/Programming/Expression)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Immutability](https://notes.yxy.ninja/Programming/Immutability)
+- [Important Rust Syntax](https://notes.yxy.ninja/Rust/Important-Rust-Syntax)
+- [Memory Safety](https://notes.yxy.ninja/OS/Memory/Memory-Safety)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Rust](https://notes.yxy.ninja/Rust/Rust)
+- [Rust Borrowing](https://notes.yxy.ninja/Rust/Rust-Borrowing)
+- [Rust Ownership](https://notes.yxy.ninja/Rust/Rust-Ownership)
+- [Rust Pending Items](https://notes.yxy.ninja/Rust/Rust-Pending-Items)
+- [Rust Toolset](https://notes.yxy.ninja/Rust/Rust-Toolset)
+- [Segmentation Fault](https://notes.yxy.ninja/OS/Memory/Segmentation-Fault)
+- [Statement](https://notes.yxy.ninja/Programming/Statement)
+
+</details>
+
+<details>
+<summary><code>js</code> · 13 notes</summary>
+
+- [Array](https://notes.yxy.ninja/Data-Structure/Array)
+- [Async IO](https://notes.yxy.ninja/OS/IO/Async-IO)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [JS Toolset](https://notes.yxy.ninja/Tools/JS/JS-Toolset)
+- [JS Weird Syntax](https://notes.yxy.ninja/Tools/JS/JS-Weird-Syntax)
+- [Middleware (中间件)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Middleware-(中间件))
+- [Node.js](https://notes.yxy.ninja/Tools/JS/Node.js)
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [Socket](https://notes.yxy.ninja/OS/Process/Socket)
+- [UDP](https://notes.yxy.ninja/Networking-Protocol/UDP)
+- [URL](https://notes.yxy.ninja/Networking-MISC/URL)
+
+</details>
+
+<details>
+<summary><code>go</code> · 7 notes</summary>
+
+- [Character Encoding (字符编码）](https://notes.yxy.ninja/Computer-Organisation/Number-System/Character-Encoding-(字符编码）)
+- [Cloudflare](https://notes.yxy.ninja/Cloudflare/Cloudflare)
+- [Garbage Collector](https://notes.yxy.ninja/OS/Memory/Garbage-Collector)
+- [Go](https://notes.yxy.ninja/Tools/Go)
+- [Goroutine](https://notes.yxy.ninja/OS/Thread/Goroutine)
+- [Mutex (互斥体)](https://notes.yxy.ninja/OS/Synchronization/Mutex-(互斥体))
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+
+</details>
+
+<details>
+<summary><code>functional</code> · 6 notes</summary>
+
+- [Closure](https://notes.yxy.ninja/Functional/Closure)
+- [Currying](https://notes.yxy.ninja/Functional/Currying)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Lazy Evaluation](https://notes.yxy.ninja/Functional/Lazy-Evaluation)
+- [Pure Function](https://notes.yxy.ninja/Functional/Pure-Function)
+
+</details>
+
+<details>
+<summary><code>OOP</code> · 18 notes</summary>
+
+- [Access Modifier](https://notes.yxy.ninja/Java/Access-Modifier)
+- [CS2030S Programming Methodology II](https://notes.yxy.ninja/NUS/CS2030S-Programming-Methodology-II)
+- [Dynamic Binding](https://notes.yxy.ninja/OOP/Dynamic-Binding)
+- [Encapsulation](https://notes.yxy.ninja/OOP/Encapsulation)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [Inheritance](https://notes.yxy.ninja/OOP/Inheritance)
+- [Java Comparison](https://notes.yxy.ninja/Java/Java-Comparison)
+- [Java Constructor](https://notes.yxy.ninja/Java/Java-Constructor)
+- [Java Lambda](https://notes.yxy.ninja/Java/Java-Lambda)
+- [Method Overloading](https://notes.yxy.ninja/OOP/Method-Overloading)
+- [Method Overriding](https://notes.yxy.ninja/OOP/Method-Overriding)
+- [OOP](https://notes.yxy.ninja/OOP/OOP)
+- [OOP Compatibility](https://notes.yxy.ninja/OOP/OOP-Compatibility)
+- [OOP Method](https://notes.yxy.ninja/OOP/OOP-Method)
+- [Polymorphism](https://notes.yxy.ninja/OOP/Polymorphism)
+- [Subtyping](https://notes.yxy.ninja/OOP/Subtyping)
+- [Type Casting](https://notes.yxy.ninja/Programming/Type-Casting)
+- [Variance](https://notes.yxy.ninja/OOP/Variance)
+
+</details>
+
+<details>
+<summary><code>oop</code> · 1 note</summary>
+
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+
+</details>
+
+<details>
+<summary><code>programming</code> · 25 notes</summary>
+
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [Argument Pointer](https://notes.yxy.ninja/Programming/Argument-Pointer)
+- [Clean Code](https://notes.yxy.ninja/Programming/Clean-Code)
+- [Common Data Structure Manipulation](https://notes.yxy.ninja/Programming/Common-Data-Structure-Manipulation)
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [Common String Manipulation](https://notes.yxy.ninja/Programming/Common-String-Manipulation)
+- [Datatype](https://notes.yxy.ninja/Programming/Datatype)
+- [Duck Typing](https://notes.yxy.ninja/Programming/Duck-Typing)
+- [Exception](https://notes.yxy.ninja/Programming/Exception)
+- [Expression](https://notes.yxy.ninja/Programming/Expression)
+- [Function](https://notes.yxy.ninja/Functional/Function)
+- [Generics](https://notes.yxy.ninja/OOP/Generics)
+- [gRPC](https://notes.yxy.ninja/Networking-MISC/gRPC)
+- [Immutability](https://notes.yxy.ninja/Programming/Immutability)
+- [Null Safety](https://notes.yxy.ninja/OS/Memory/Null-Safety)
+- [Pointer](https://notes.yxy.ninja/Programming/Pointer)
+- [Python Behavior](https://notes.yxy.ninja/Python/Python-Behavior)
+- [Python Iterable vs Iterator vs Generator](https://notes.yxy.ninja/Python/Python-Iterable-vs-Iterator-vs-Generator)
+- [Pythonic Codes](https://notes.yxy.ninja/Programming/Pythonic-Codes)
+- [Statement](https://notes.yxy.ninja/Programming/Statement)
+- [String Interpolation](https://notes.yxy.ninja/Programming/String-Interpolation)
+- [Syntactic Scope](https://notes.yxy.ninja/Programming/Syntactic-Scope)
+- [Type Erasure](https://notes.yxy.ninja/Programming/Type-Erasure)
+- [Type Safety](https://notes.yxy.ninja/Programming/Type-Safety)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+
+</details>
+
+</details>
+
+<a id="software-engineering-tooling"></a>
+<details>
+<summary><strong>Software Engineering & Tooling</strong></summary>
+
+<details>
+<summary><code>software_engineering</code> · 28 notes</summary>
+
+- [Abstraction](https://notes.yxy.ninja/Software-Engineering/Abstraction)
+- [Alert](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Alert)
+- [Application Performance Monitoring (APM)](https://notes.yxy.ninja/Software-Engineering/Monitoring/Application-Performance-Monitoring-(APM))
+- [Code Bundling](https://notes.yxy.ninja/Software-Engineering/Terminologies/Code-Bundling)
+- [Code Editor Setup](https://notes.yxy.ninja/Software-Engineering/Code-Editor-Setup)
+- [Code for Change](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Code-for-Change)
+- [Code Quality Assurance Tools](https://notes.yxy.ninja/Software-Engineering/Code-Quality-Assurance-Tools)
+- [Coding Convention](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Coding-Convention)
+- [Data Layer Abstraction](https://notes.yxy.ninja/Software-Engineering/Data-Layer-Abstraction)
+- [Language Processors](https://notes.yxy.ninja/Software-Engineering/Language-Processors)
+- [Liskov Substitution Principle (LSP)](https://notes.yxy.ninja/Software-Engineering/SOLID-Design-Principles/Liskov-Substitution-Principle-(LSP))
+- [Middleware (中间件)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Middleware-(中间件))
+- [Mono Repos](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/Mono-Repos)
+- [Monorepo Build System](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/Monorepo-Build-System)
+- [nx](https://notes.yxy.ninja/Software-Engineering/Code-Management/Mono-Repos/nx)
+- [Package Manager](https://notes.yxy.ninja/Software-Engineering/Package-Manager)
+- [ReactJS](https://notes.yxy.ninja/Tools/ReactJS)
+- [ReactJS Common Mistakes](https://notes.yxy.ninja/Tools/ReactJS-Common-Mistakes)
+- [Real User Monitoring](https://notes.yxy.ninja/Software-Engineering/Monitoring/Real-User-Monitoring)
+- [Sampling](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Sampling)
+- [Semantic Versioning](https://notes.yxy.ninja/Programming/Semantic-Versioning)
+- [Shim (垫片)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Shim-(垫片))
+- [Software Development Practices](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Software-Development-Practices)
+- [Span](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Span)
+- [Terminal](https://notes.yxy.ninja/Software-Engineering/Terminal)
+- [Trace](https://notes.yxy.ninja/Software-Engineering/Monitoring/terminologies/Trace)
+- [Type Inference (类型推断)](https://notes.yxy.ninja/Software-Engineering/Terminologies/Type-Inference-(类型推断))
+- [Type System](https://notes.yxy.ninja/Programming/Type-System)
+
+</details>
+
+<details>
+<summary><code>bash</code> · 26 notes</summary>
+
+- [Asymmetric Cryptography](https://notes.yxy.ninja/Security/Cryptography/Asymmetric-Cryptography)
+- [Atuin](https://notes.yxy.ninja/Bash/Atuin)
+- [Bash Script Parameter Handling](https://notes.yxy.ninja/Bash/Bash-Script-Parameter-Handling)
+- [Bash Scripting](https://notes.yxy.ninja/Bash/Bash-Scripting)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [DNS](https://notes.yxy.ninja/Networking-Protocol/DNS/DNS)
+- [File](https://notes.yxy.ninja/OS/File-System/File)
+- [File Compression](https://notes.yxy.ninja/OS/File-System/File-Compression)
+- [File System](https://notes.yxy.ninja/OS/File-System/File-System)
+- [File System Hierarchy](https://notes.yxy.ninja/OS/File-System/File-System-Hierarchy)
+- [File System Link](https://notes.yxy.ninja/OS/File-System/File-System-Link)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [Inode](https://notes.yxy.ninja/OS/File-System/Inode)
+- [Instruction Set Architecture (ISA)](https://notes.yxy.ninja/Computer-Organisation/Instruction-Set-Architecture-(ISA)/Instruction-Set-Architecture-(ISA))
+- [IO Device](https://notes.yxy.ninja/OS/IO/IO-Device)
+- [IP Address](https://notes.yxy.ninja/Networking-Protocol/DNS/IP-Address)
+- [jq](https://notes.yxy.ninja/Bash/Networking/jq)
+- [netstat](https://notes.yxy.ninja/Bash/Networking/netstat)
+- [Network Port](https://notes.yxy.ninja/Networking-MISC/Network-Port)
+- [scp](https://notes.yxy.ninja/Bash/Networking/scp)
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Swap Space](https://notes.yxy.ninja/OS/Memory/Swap-Space)
+- [Systemd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Systemd)
+- [TCP](https://notes.yxy.ninja/Networking-Protocol/TCP/TCP)
+- [Terminal](https://notes.yxy.ninja/Software-Engineering/Terminal)
+- [Timezone](https://notes.yxy.ninja/Terminologies/Timezone)
+
+</details>
+
+<details>
+<summary><code>git</code> · 3 notes</summary>
+
+- [Git](https://notes.yxy.ninja/Tools/Git/Git)
+- [Git Hook](https://notes.yxy.ninja/Tools/Git/Git-Hook)
+- [Git Rebase](https://notes.yxy.ninja/Tools/Git/Git-Rebase)
+
+</details>
+
+<details>
+<summary><code>backend_dev</code> · 1 note</summary>
+
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+
+</details>
+
+<details>
+<summary><code>wechat</code> · 1 note</summary>
+
+- [WeChat API](https://notes.yxy.ninja/Tools/WeChat-API)
+
+</details>
+
+</details>
+
+<a id="algorithms-data-structures-math"></a>
+<details>
+<summary><strong>Algorithms, Data Structures & Math</strong></summary>
+
+<details>
+<summary><code>dsa</code> · 53 notes</summary>
+
+- [Abstract Data Type (ADT)](https://notes.yxy.ninja/Data-Structure/Abstract-Data-Type-(ADT))
+- [Algorithm](https://notes.yxy.ninja/Algorithm/Algorithm)
+- [Algorithm Complexity Analysis](https://notes.yxy.ninja/Algorithm/Algorithm-Complexity-Analysis)
+- [Algorithm Content Page](https://notes.yxy.ninja/Algorithm/Algorithm-Content-Page)
+- [Array](https://notes.yxy.ninja/Data-Structure/Array)
+- [AVL Tree](https://notes.yxy.ninja/Data-Structure/Tree/AVL-Tree)
+- [Backtracking](https://notes.yxy.ninja/Algorithm/Recursion/Backtracking)
+- [Banker's Algorithm](https://notes.yxy.ninja/Algorithm/Banker's-Algorithm)
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+- [BFS](https://notes.yxy.ninja/Algorithm/BFS)
+- [Binary Search](https://notes.yxy.ninja/Algorithm/Binary-Search)
+- [Binary Search in Rotated Sorted Array](https://notes.yxy.ninja/Algorithm/Binary-Search-in-Rotated-Sorted-Array)
+- [Binary Search Tree (二叉搜索树)](https://notes.yxy.ninja/Data-Structure/Tree/Binary-Search-Tree-(二叉搜索树))
+- [Binary Tree](https://notes.yxy.ninja/Data-Structure/Tree/Binary-Tree)
+- [Binomial Coefficient](https://notes.yxy.ninja/Discrete-Math/We-Count/Binomial-Coefficient)
+- [Combinatorial Optimisation](https://notes.yxy.ninja/Algorithm/Optimisation/Combinatorial-Optimisation)
+- [Complete Binary Tree (完全二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Complete-Binary-Tree-(完全二叉树))
+- [CS2040S Data Structures and Algorithms](https://notes.yxy.ninja/NUS/CS2040S-Data-Structures-and-Algorithms)
+- [Data Structure](https://notes.yxy.ninja/Data-Structure/Data-Structure)
+- [Data Structure Content Page](https://notes.yxy.ninja/Data-Structure/Data-Structure-Content-Page)
+- [Deque](https://notes.yxy.ninja/Data-Structure/Deque)
+- [DFS](https://notes.yxy.ninja/Algorithm/Recursion/DFS)
+- [DFS vs BFS vs Backtracking](https://notes.yxy.ninja/Algorithm/DFS-vs-BFS-vs-Backtracking)
+- [Dijkstra's Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Dijkstra's-Algorithm)
+- [DSA Algorithm Template](https://notes.yxy.ninja/Templates/DSA-Algorithm-Template)
+- [Dynamic Programming](https://notes.yxy.ninja/Algorithm/Optimisation/Dynamic-Programming)
+- [Full Binary Tree (完满二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Full-Binary-Tree-(完满二叉树))
+- [Genetic Algorithms](https://notes.yxy.ninja/Algorithm/Genetic-Algorithms)
+- [Graph](https://notes.yxy.ninja/Data-Structure/Graph)
+- [Greedy Algorithm](https://notes.yxy.ninja/Algorithm/Optimisation/Greedy-Algorithm)
+- [Hash Collision](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Collision)
+- [Hash Function](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Function)
+- [Hash Map](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Map)
+- [Heap](https://notes.yxy.ninja/Data-Structure/Heap)
+- [Interval](https://notes.yxy.ninja/Algorithm/terminologies/Interval)
+- [Kadane's algorithm](https://notes.yxy.ninja/Algorithm/Kadane's-algorithm)
+- [Kahn's Algorithm](https://notes.yxy.ninja/Algorithm/Kahn's-Algorithm)
+- [Linked List](https://notes.yxy.ninja/Data-Structure/Linked-List)
+- [Memoization](https://notes.yxy.ninja/Algorithm/Optimisation/Memoization)
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+- [Perfect Binary Tree (完美二叉树)](https://notes.yxy.ninja/Data-Structure/Tree/Perfect-Binary-Tree-(完美二叉树))
+- [Prefix Sum (前缀和)](https://notes.yxy.ninja/Algorithm/Prefix-Sum-(前缀和))
+- [Priority Queue](https://notes.yxy.ninja/Data-Structure/Priority-Queue)
+- [Pseudo-Random Number Generation](https://notes.yxy.ninja/Algorithm/Pseudo-Random-Number-Generation)
+- [Queue](https://notes.yxy.ninja/Data-Structure/Queue)
+- [Quick Select](https://notes.yxy.ninja/Algorithm/Quick-Select)
+- [Recursion](https://notes.yxy.ninja/Algorithm/Recursion/Recursion)
+- [Sorting](https://notes.yxy.ninja/Algorithm/Recursion/Sorting)
+- [Stack](https://notes.yxy.ninja/Data-Structure/Stack)
+- [Sub-Sequence](https://notes.yxy.ninja/Algorithm/terminologies/Sub-Sequence)
+- [Tree](https://notes.yxy.ninja/Data-Structure/Tree/Tree)
+- [Two Pointers (双指针)](https://notes.yxy.ninja/Algorithm/Two-Pointers-(双指针))
+- [Union Find](https://notes.yxy.ninja/Data-Structure/Union-Find)
+
+</details>
+
+<details>
+<summary><code>cp</code> · 28 notes</summary>
+
+- [(CodeForces) A Balanced Problem set?](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-A-Balanced-Problem-set?)
+- [(CodeForces) All The Same](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-All-The-Same)
+- [(CodeForces) Almost Ternary Matrix](https://notes.yxy.ninja/cp/dynamic_programming/(CodeForces)-Almost-Ternary-Matrix)
+- [(CodeForces) Divisibility](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Divisibility)
+- [(CodeForces) Equalize](https://notes.yxy.ninja/cp/greedy/(CodeForces)-Equalize)
+- [(CodeForces) Forming Triangles](https://notes.yxy.ninja/cp/combinatorics/(CodeForces)-Forming-Triangles)
+- [(CodeForces) Minimize Inversions](https://notes.yxy.ninja/cp/greedy/(CodeForces)-Minimize-Inversions)
+- [(CodeForces) Non-coprime Split](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Non-coprime-Split)
+- [(CodeForces) Partitioning the Array](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Partitioning-the-Array)
+- [(CodeForces) Rectangle Cutting](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Rectangle-Cutting)
+- [(CodeForces) Rectangular Game](https://notes.yxy.ninja/cp/number_theory/(CodeForces)-Rectangular-Game)
+- [Closest Cities](https://notes.yxy.ninja/cp/prefix_sum/Closest-Cities)
+- [Competitive Programming Code Templates](https://notes.yxy.ninja/cp/Competitive-Programming-Code-Templates)
+- [Container With Most Water](https://notes.yxy.ninja/cp/greedy/Container-With-Most-Water)
+- [cp](https://notes.yxy.ninja/Templates/cp)
+- [CP Tips](https://notes.yxy.ninja/cp/CP-Tips)
+- [Leetcode - House Robber](https://notes.yxy.ninja/cp/dynamic_programming/Leetcode---House-Robber)
+- [Leetcode - Product of Array Except Self](https://notes.yxy.ninja/cp/prefix_sum/Leetcode---Product-of-Array-Except-Self)
+- [LRU](https://notes.yxy.ninja/cp/data_structure/LRU)
+- [Next Permutation](https://notes.yxy.ninja/cp/greedy/Next-Permutation)
+- [Pasha and Stick](https://notes.yxy.ninja/cp/combinatorics/Pasha-and-Stick)
+- [Pending CP Questions](https://notes.yxy.ninja/cp/Pending-CP-Questions)
+- [Romantic Glasses](https://notes.yxy.ninja/cp/prefix_sum/Romantic-Glasses)
+- [Square Difference](https://notes.yxy.ninja/cp/Square-Difference)
+- [Valid Sudoku](https://notes.yxy.ninja/cp/data_structure/Valid-Sudoku)
+- [Word Break](https://notes.yxy.ninja/cp/dynamic_programming/Word-Break)
+- [XOR](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/XOR)
+- [YetnotherrokenKeoard](https://notes.yxy.ninja/cp/data_structure/YetnotherrokenKeoard)
+
+</details>
+
+<details>
+<summary><code>problem_solving</code> · 2 notes</summary>
+
+- [Problem Solving](https://notes.yxy.ninja/Problem-solving/Problem-Solving)
+- [Problem Solving Sample Problem](https://notes.yxy.ninja/Problem-solving/Problem-Solving-Sample-Problem)
+
+</details>
+
+<details>
+<summary><code>math</code> · 3 notes</summary>
+
+- [Fermi Problem](https://notes.yxy.ninja/Math/Fermi-Problem)
+- [Sequence](https://notes.yxy.ninja/Math/Sequence)
+- [Series](https://notes.yxy.ninja/Math/Series)
+
+</details>
+
+<details>
+<summary><code>discrete_math</code> · 44 notes</summary>
+
+- [Cartesian Product](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Cartesian-Product)
+- [Combination](https://notes.yxy.ninja/Discrete-Math/We-Count/Combination)
+- [Combinatorics](https://notes.yxy.ninja/Discrete-Math/We-Count/Combinatorics)
+- [Conditional Statement](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Conditional-Statement)
+- [Counting](https://notes.yxy.ninja/Discrete-Math/We-Count/Counting)
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Deductive Reasoning (演繹推理)](https://notes.yxy.ninja/Discrete-Math/Deductive-Reasoning-(演繹推理))
+- [Direct Proof](https://notes.yxy.ninja/Discrete-Math/Direct-Proof)
+- [Discrete Geometry](https://notes.yxy.ninja/Discrete-Math/Discrete-Geometry)
+- [Discrete Math](https://notes.yxy.ninja/Discrete-Math/Discrete-Math)
+- [Divisibility (可除性)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Divisibility-(可除性))
+- [Empty Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Empty-Set)
+- [Equivalence Relation](https://notes.yxy.ninja/Discrete-Math/Equivalence-Relation)
+- [Existential Statement](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Existential-Statement)
+- [Fallacy](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Fallacy)
+- [Graph](https://notes.yxy.ninja/Data-Structure/Graph)
+- [Indirect Proof](https://notes.yxy.ninja/Discrete-Math/Indirect-Proof)
+- [Mathematical Argument](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Mathematical-Argument)
+- [Mathematical Function](https://notes.yxy.ninja/Discrete-Math/Mathematical-Function)
+- [Mathematical Proof](https://notes.yxy.ninja/Discrete-Math/Mathematical-Proof)
+- [Mathematical Statement](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Mathematical-Statement)
+- [Mutually Disjoin Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Mutually-Disjoin-Set)
+- [Ordered Pair](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Ordered-Pair)
+- [Partial Order](https://notes.yxy.ninja/Discrete-Math/Partial-Order)
+- [Permutation](https://notes.yxy.ninja/Discrete-Math/We-Count/Permutation)
+- [Power Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Power-Set)
+- [Predicate](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Predicate)
+- [Properties of Integer](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Properties-of-Integer)
+- [Propositional Logic](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Propositional-Logic)
+- [Quantified Rule of Inference](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Quantified-Rule-of-Inference)
+- [Quantifier](https://notes.yxy.ninja/Discrete-Math/Quantified-Statements/Quantifier)
+- [Rational Number](https://notes.yxy.ninja/Number-Theory/Rational-Number)
+- [Relation](https://notes.yxy.ninja/Discrete-Math/Relation)
+- [Relation Composition](https://notes.yxy.ninja/Discrete-Math/Relation-Composition)
+- [Relation Property](https://notes.yxy.ninja/Discrete-Math/Relation-Property)
+- [Rule of Inference (推理规则)](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Rule-of-Inference-(推理规则))
+- [Sequence](https://notes.yxy.ninja/Math/Sequence)
+- [Series](https://notes.yxy.ninja/Math/Series)
+- [Set](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set)
+- [Set Equality](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Equality)
+- [Set Notation](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Notation)
+- [Set Partition](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Partition)
+- [Set Theorem](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Set-Theorem)
+- [Subset](https://notes.yxy.ninja/Discrete-Math/Set-Theory/Subset)
+
+</details>
+
+<details>
+<summary><code>number_theory</code> · 10 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Divisibility (可除性)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Divisibility-(可除性))
+- [Factor](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Factor)
+- [GCD](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/GCD)
+- [Integer (整数)](https://notes.yxy.ninja/Number-Theory/Integer-(整数))
+- [Modulo](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Modulo)
+- [Prime Number (质数)](https://notes.yxy.ninja/Number-Theory/Divisibility-and-Primes/Prime-Number-(质数))
+- [Properties of Integer](https://notes.yxy.ninja/Discrete-Math/Speaking-Mathematically-and-Logically/Properties-of-Integer)
+- [Rational Number](https://notes.yxy.ninja/Number-Theory/Rational-Number)
+- [Real Number](https://notes.yxy.ninja/Number-Theory/Real-Number)
+
+</details>
+
+<details>
+<summary><code>probability</code> · 3 notes</summary>
+
+- [Binomial Coefficient](https://notes.yxy.ninja/Discrete-Math/We-Count/Binomial-Coefficient)
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Probability Problems](https://notes.yxy.ninja/Probability/Probability-Problems)
+
+</details>
+
+<details>
+<summary><code>geometry</code> · 2 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [Discrete Geometry](https://notes.yxy.ninja/Discrete-Math/Discrete-Geometry)
+
+</details>
+
+<details>
+<summary><code>calculus</code> · 1 note</summary>
+
+- [Relation](https://notes.yxy.ninja/Discrete-Math/Relation)
+
+</details>
+
+<details>
+<summary><code>graph</code> · 3 notes</summary>
+
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+- [DFS vs BFS vs Backtracking](https://notes.yxy.ninja/Algorithm/DFS-vs-BFS-vs-Backtracking)
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+
+</details>
+
+<details>
+<summary><code>shortest-path</code> · 1 note</summary>
+
+- [Bellman-Ford Algorithm](https://notes.yxy.ninja/Algorithm/Bellman-Ford-Algorithm)
+
+</details>
+
+<details>
+<summary><code>optimization</code> · 1 note</summary>
+
+- [Minimum Spanning Tree](https://notes.yxy.ninja/Data-Structure/Minimum-Spanning-Tree)
+
+</details>
+
+</details>
+
+<a id="data-management"></a>
+<details>
+<summary><strong>Data Management</strong></summary>
+
+<details>
+<summary><code>database</code> · 11 notes</summary>
+
+- [ACID Transactions](https://notes.yxy.ninja/Database/ACID-Transactions)
+- [Database](https://notes.yxy.ninja/Database/Database)
+- [Database Collation](https://notes.yxy.ninja/Database/Database-Collation)
+- [Database Comparison](https://notes.yxy.ninja/Database/Database-Comparison)
+- [Database Indexing](https://notes.yxy.ninja/Database/Database-Indexing)
+- [Database Paradigms](https://notes.yxy.ninja/Database/Database-Paradigms)
+- [Database Partitioning](https://notes.yxy.ninja/Database/Database-Partitioning)
+- [Database Search](https://notes.yxy.ninja/Database/Database-Search)
+- [DuckDB](https://notes.yxy.ninja/Database/DuckDB)
+- [MySQL](https://notes.yxy.ninja/Database/MySQL)
+- [SQL](https://notes.yxy.ninja/Database/SQL)
+
+</details>
+
+<details>
+<summary><code>sql</code> · 2 notes</summary>
+
+- [Common Programming Operations](https://notes.yxy.ninja/Programming/Common-Programming-Operations)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+
+</details>
+
+<details>
+<summary><code>postgres</code> · 1 note</summary>
+
+- [Postgres](https://notes.yxy.ninja/Database/Postgres)
+
+</details>
+
+</details>
+
+<a id="security-identity"></a>
+<details>
+<summary><strong>Security & Identity</strong></summary>
+
+<details>
+<summary><code>security</code> · 33 notes</summary>
+
+- [Access Control List](https://notes.yxy.ninja/Security/Access-Control-List)
+- [Asymmetric Cryptography](https://notes.yxy.ninja/Security/Cryptography/Asymmetric-Cryptography)
+- [Authentication](https://notes.yxy.ninja/Security/Authentication/Authentication)
+- [Authorisation](https://notes.yxy.ninja/Security/Authorisation/Authorisation)
+- [AWS ACL](https://notes.yxy.ninja/AWS/Security/AWS-ACL)
+- [Ciphertext (密文)](https://notes.yxy.ninja/Security/Terminologies/Ciphertext-(密文))
+- [Cloudflare Access](https://notes.yxy.ninja/Security/Authentication/Cloudflare-Access)
+- [Common Security Attacks](https://notes.yxy.ninja/Security/Common-Security-Attacks)
+- [Computer Network](https://notes.yxy.ninja/Networking-Concepts/Computer-Network)
+- [Cookie](https://notes.yxy.ninja/Security/Authentication/Cookie)
+- [Digital Signature](https://notes.yxy.ninja/Security/Cryptography/Digital-Signature)
+- [Dynamic Secrets](https://notes.yxy.ninja/Security/Dynamic-Secrets)
+- [Email Security](https://notes.yxy.ninja/Security/Email-Security)
+- [Encryption](https://notes.yxy.ninja/Security/Encryption)
+- [Hash Digest](https://notes.yxy.ninja/Security/Cryptography/Hash-Digest)
+- [Hash Function](https://notes.yxy.ninja/Data-Structure/Hash-Map/Hash-Function)
+- [HMAC (Hash-Based Message Authentication Code)](https://notes.yxy.ninja/Security/Cryptography/HMAC-(Hash-Based-Message-Authentication-Code))
+- [HTTP Basic Authentication](https://notes.yxy.ninja/Security/Authentication/HTTP-Basic-Authentication)
+- [JWT](https://notes.yxy.ninja/Security/Authentication/JWT)
+- [Key's Randomart Image](https://notes.yxy.ninja/Security/Terminologies/Key's-Randomart-Image)
+- [OAuth 2.0](https://notes.yxy.ninja/Security/Authorisation/OAuth-2.0)
+- [OIDC Authentication](https://notes.yxy.ninja/Security/Authentication/OIDC-Authentication)
+- [PEM (Privacy Enhanced Mail)](https://notes.yxy.ninja/Security/PEM-(Privacy-Enhanced-Mail))
+- [Salting](https://notes.yxy.ninja/Security/Cryptography/Salting)
+- [Security Group](https://notes.yxy.ninja/AWS/Security/Security-Group)
+- [Session-Cookie Authentication](https://notes.yxy.ninja/Security/Authentication/Session-Cookie-Authentication)
+- [Shift-left Security](https://notes.yxy.ninja/Security/Terminologies/Shift-left-Security)
+- [Single Sign-On (SSO)](https://notes.yxy.ninja/Security/Authentication/Single-Sign-On-(SSO))
+- [SSH](https://notes.yxy.ninja/Networking-Protocol/SSH)
+- [Symmetric Encryption](https://notes.yxy.ninja/Security/Cryptography/Symmetric-Encryption)
+- [Token-Based Authentication](https://notes.yxy.ninja/Security/Authentication/Token-Based-Authentication)
+- [User Principle Name](https://notes.yxy.ninja/Security/Authentication/User-Principle-Name)
+- [X.509 Certificate](https://notes.yxy.ninja/Networking-Protocol/TLS/X.509-Certificate)
+
+</details>
+
+<details>
+<summary><code>binance</code> · 16 notes</summary>
+
+- [API Notes](https://notes.yxy.ninja/Tools/API-Notes)
+- [Cron Job](https://notes.yxy.ninja/Bash/Cron-Job)
+- [Data Layer Abstraction](https://notes.yxy.ninja/Software-Engineering/Data-Layer-Abstraction)
+- [Database Collation](https://notes.yxy.ninja/Database/Database-Collation)
+- [Database Indexing](https://notes.yxy.ninja/Database/Database-Indexing)
+- [Database Search](https://notes.yxy.ninja/Database/Database-Search)
+- [Java Optional](https://notes.yxy.ninja/Java/Java-Optional)
+- [Java Sprintboot](https://notes.yxy.ninja/Tools/Java-Sprintboot)
+- [Launchd](https://notes.yxy.ninja/OS/UNIX-vs-Linux/Launchd)
+- [Monitoring](https://notes.yxy.ninja/Devops/Monitoring)
+- [Observability](https://notes.yxy.ninja/Devops/Observability)
+- [Prometheus](https://notes.yxy.ninja/Devops/Prometheus)
+- [Prometheus On Macos](https://notes.yxy.ninja/Devops/Prometheus-On-Macos)
+- [PromQL](https://notes.yxy.ninja/Devops/PromQL)
+- [SQL Batch Processing](https://notes.yxy.ninja/Database/SQL-Batch-Processing)
+- [Web Scraping](https://notes.yxy.ninja/Programming/Web-Scraping)
+
+</details>
+
+</details>
+
+<a id="career-finance-academia"></a>
+<details>
+<summary><strong>Career, Finance & Academia</strong></summary>
+
+<details>
+<summary><code>career</code> · 1 note</summary>
+
+- [Negotiation](https://notes.yxy.ninja/Career/Negotiation)
+
+</details>
+
+<details>
+<summary><code>interview</code> · 1 note</summary>
+
+- [Mock Interviews](https://notes.yxy.ninja/Interview/Mock-Interviews)
+
+</details>
+
+<details>
+<summary><code>finance</code> · 7 notes</summary>
+
+- [Affiliate Business](https://notes.yxy.ninja/Finance/Affiliate-Business)
+- [Card Strategy as a Student](https://notes.yxy.ninja/Finance/Card-Strategy-as-a-Student)
+- [Credit Card](https://notes.yxy.ninja/Finance/Credit-Card)
+- [Income Tax Relief](https://notes.yxy.ninja/Finance/Income-Tax-Relief)
+- [Market Liquidity](https://notes.yxy.ninja/Finance/Market-Liquidity)
+- [Market Maker](https://notes.yxy.ninja/Finance/Market-Maker)
+- [Negotiation](https://notes.yxy.ninja/Career/Negotiation)
+
+</details>
+
+<details>
+<summary><code>nus</code> · 4 notes</summary>
+
+- [CS1231S Discrete Structures](https://notes.yxy.ninja/NUS/CS1231S-Discrete-Structures)
+- [CS2040S Data Structures and Algorithms](https://notes.yxy.ninja/NUS/CS2040S-Data-Structures-and-Algorithms)
+- [CS2100 Computer Organisation](https://notes.yxy.ninja/NUS/CS2100-Computer-Organisation)
+- [CS2106 Introduction to Operating Systems](https://notes.yxy.ninja/NUS/CS2106-Introduction-to-Operating-Systems)
+
+</details>
+
+<details>
+<summary><code>cs2030s</code> · 4 notes</summary>
+
+- [Code for Change](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Code-for-Change)
+- [Coding Convention](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Coding-Convention)
+- [Software Development Practices](https://notes.yxy.ninja/Software-Engineering/Managing-Complexity/Software-Development-Practices)
+- [Type System](https://notes.yxy.ninja/Programming/Type-System)
+
+</details>
+
+<details>
+<summary><code>hacktron</code> · 2 notes</summary>
+
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+
+</details>
+
+</details>
+
+<a id="ai-emerging-tech"></a>
+<details>
+<summary><strong>AI & Emerging Tech</strong></summary>
+
+<details>
+<summary><code>ai</code> · 1 note</summary>
+
+- [HPC AI](https://notes.yxy.ninja/Hpc/HPC-AI)
+
+</details>
+
+</details>
+
+<a id="visual-library"></a>
+<details>
+<summary><strong>Visual Library</strong></summary>
+
+<details>
+<summary><code>excalidraw</code> · 3 notes</summary>
+
+- [base64_encoding.excalidraw](https://notes.yxy.ninja/Computer-Organisation/excalidraw/base64_encoding.excalidraw)
+- [Container With Most Water.excalidraw](https://notes.yxy.ninja/cp/greedy/excalidraw/Container-With-Most-Water.excalidraw)
+- [World Break.excalidraw](https://notes.yxy.ninja/cp/dynamic_programming/excalidraw/World-Break.excalidraw)
+
+</details>
+
+</details>

--- a/content/index.md
+++ b/content/index.md
@@ -33,13 +33,18 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 | [Algorithms, Data Structures & Math](#algorithms-data-structures-math) | Problem-solving playbooks, math fundamentals, and contest prep |
 | [Data Management](#data-management) | Relational theory, storage engines, and SQL patterns |
 | [Security & Identity](#security-identity) | Security architecture, authentication, and enterprise trust |
+| [Past Job Experience](#past-job-experience) | Highlights from Binance, Hacktron, and Opcode workstreams |
 | [Career, Finance & Academia](#career-finance-academia) | Professional growth, financial literacy, and academic references |
+| [NUS](#nus) | School coursework, module notes, and academic projects |
 | [AI & Emerging Tech](#ai-emerging-tech) | High-performance AI workloads and modern ML infrastructure |
-| [Visual Library](#visual-library) | Hand-crafted Excalidraw diagrams and visual aids |
 
-<a id="architecture-cloud-operations"></a>
+<div class="domain-grid" style="display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); align-items: stretch;">
+
+<div id="architecture-cloud-operations" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Architecture, Cloud & Operations</strong></summary>
+
+<p><em>System design blueprints, observability, and cloud platform building blocks</em></p>
 
 <details>
 <summary><code>system_design</code> · 24 notes</summary>
@@ -203,9 +208,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="networking-distributed-systems"></a>
+</details>
+</div>
+
+<div id="networking-distributed-systems" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Networking & Distributed Systems</strong></summary>
+
+<p><em>Protocols, distributed primitives, and edge connectivity</em></p>
 
 <details>
 <summary><code>networking</code> · 95 notes</summary>
@@ -329,9 +339,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="operating-systems-hardware-hpc"></a>
+</details>
+</div>
+
+<div id="operating-systems-hardware-hpc" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Operating Systems, Hardware & HPC</strong></summary>
+
+<p><em>Kernel internals, memory models, and digital logic</em></p>
 
 <details>
 <summary><code>OS</code> · 109 notes</summary>
@@ -616,13 +631,6 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 </details>
 
 <details>
-<summary><code>opcode</code> · 1 note</summary>
-
-- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
-
-</details>
-
-<details>
 <summary><code>boolean_algebra</code> · 11 notes</summary>
 
 - [AND](https://notes.yxy.ninja/Boolean-Algebra/Logic-Gates/AND)
@@ -641,9 +649,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="programming-languages-paradigms"></a>
+</details>
+</div>
+
+<div id="programming-languages-paradigms" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Programming Languages & Paradigms</strong></summary>
+
+<p><em>Language idioms, paradigms, and ecosystem insights</em></p>
 
 <details>
 <summary><code>c</code> · 17 notes</summary>
@@ -886,9 +899,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="software-engineering-tooling"></a>
+</details>
+</div>
+
+<div id="software-engineering-tooling" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Software Engineering & Tooling</strong></summary>
+
+<p><em>Engineering workflows, CLI mastery, and productivity tooling</em></p>
 
 <details>
 <summary><code>software_engineering</code> · 28 notes</summary>
@@ -981,9 +999,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="algorithms-data-structures-math"></a>
+</details>
+</div>
+
+<div id="algorithms-data-structures-math" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Algorithms, Data Structures & Math</strong></summary>
+
+<p><em>Problem-solving playbooks, math fundamentals, and contest prep</em></p>
 
 <details>
 <summary><code>dsa</code> · 53 notes</summary>
@@ -1210,9 +1233,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="data-management"></a>
+</details>
+</div>
+
+<div id="data-management" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Data Management</strong></summary>
+
+<p><em>Relational theory, storage engines, and SQL patterns</em></p>
 
 <details>
 <summary><code>database</code> · 11 notes</summary>
@@ -1248,9 +1276,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<a id="security-identity"></a>
+</details>
+</div>
+
+<div id="security-identity" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Security & Identity</strong></summary>
+
+<p><em>Security architecture, authentication, and enterprise trust</em></p>
 
 <details>
 <summary><code>security</code> · 33 notes</summary>
@@ -1291,6 +1324,17 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+</details>
+
+</details>
+</div>
+
+<div id="past-job-experience" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
+<details>
+<summary><strong>Past Job Experience</strong></summary>
+
+<p><em>Highlights from Binance, Hacktron, and Opcode workstreams</em></p>
+
 <details>
 <summary><code>binance</code> · 16 notes</summary>
 
@@ -1313,11 +1357,29 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+<details>
+<summary><code>hacktron</code> · 2 notes</summary>
+
+- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
+- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
+
 </details>
 
-<a id="career-finance-academia"></a>
+<details>
+<summary><code>opcode</code> · 1 note</summary>
+
+- [Multicast](https://notes.yxy.ninja/Networking-Concepts/Multicast)
+
+</details>
+
+</details>
+</div>
+
+<div id="career-finance-academia" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>Career, Finance & Academia</strong></summary>
+
+<p><em>Professional growth, financial literacy, and academic references</em></p>
 
 <details>
 <summary><code>career</code> · 1 note</summary>
@@ -1346,6 +1408,17 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
+</details>
+
+</details>
+</div>
+
+<div id="nus" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
+<details>
+<summary><strong>NUS</strong></summary>
+
+<p><em>School coursework, module notes, and academic projects</em></p>
+
 <details>
 <summary><code>nus</code> · 4 notes</summary>
 
@@ -1366,19 +1439,14 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 
 </details>
 
-<details>
-<summary><code>hacktron</code> · 2 notes</summary>
-
-- [Event Loop](https://notes.yxy.ninja/OS/Thread/Event-Loop)
-- [Redis Deployment](https://notes.yxy.ninja/Devops/Redis-Deployment)
-
 </details>
+</div>
 
-</details>
-
-<a id="ai-emerging-tech"></a>
+<div id="ai-emerging-tech" class="domain-card" style="border: 1px solid var(--card-border, rgba(128, 128, 128, 0.25)); border-radius: 16px; padding: 1.25rem; background: var(--card-background, rgba(255, 255, 255, 0.04)); box-shadow: 0 12px 30px rgba(0, 0, 0, 0.08);">
 <details>
 <summary><strong>AI & Emerging Tech</strong></summary>
+
+<p><em>High-performance AI workloads and modern ML infrastructure</em></p>
 
 <details>
 <summary><code>ai</code> · 1 note</summary>
@@ -1388,18 +1456,6 @@ Use the quick index below to jump straight to the topics you care about. Expand 
 </details>
 
 </details>
+</div>
 
-<a id="visual-library"></a>
-<details>
-<summary><strong>Visual Library</strong></summary>
-
-<details>
-<summary><code>excalidraw</code> · 3 notes</summary>
-
-- [base64_encoding.excalidraw](https://notes.yxy.ninja/Computer-Organisation/excalidraw/base64_encoding.excalidraw)
-- [Container With Most Water.excalidraw](https://notes.yxy.ninja/cp/greedy/excalidraw/Container-With-Most-Water.excalidraw)
-- [World Break.excalidraw](https://notes.yxy.ninja/cp/dynamic_programming/excalidraw/World-Break.excalidraw)
-
-</details>
-
-</details>
+</div>


### PR DESCRIPTION
## Summary
- add a quick-jump index for the Notes Navigator section
- group each topic collection into collapsible details for easier scanning
- tidy the lists so anchors are linkable and consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690600c5fa388332a03f91e6d065793f